### PR TITLE
feat(monitoring): add MCP probe alerting

### DIFF
--- a/monitoring/mcp-probe/package.json
+++ b/monitoring/mcp-probe/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "mcp-probe",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": "24.x"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "gcp-build": "npm run build",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.10",
+    "typescript": "^5.8.3"
+  }
+}

--- a/monitoring/mcp-probe/src/index.ts
+++ b/monitoring/mcp-probe/src/index.ts
@@ -1,0 +1,98 @@
+import { createServer, type ServerResponse } from "node:http";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import {
+  drainRequest,
+  handleInvalidRequest,
+  resolveProbeConfig,
+  runProbe,
+  sendJsonResponse,
+  type ProbeClient,
+  type ProbeLogRecord,
+} from "./probe.js";
+
+const config = resolveProbeConfig(process.env);
+const port = resolvePort(process.env.PORT);
+
+const logRecord = (record: ProbeLogRecord): void => {
+  const payload = `${JSON.stringify(record)}\n`;
+  if (record.severity === "ERROR" || record.severity === "WARNING") {
+    process.stderr.write(payload);
+    return;
+  }
+  process.stdout.write(payload);
+};
+
+const server = createServer(async (req, res) => {
+  const method = req.method ?? "GET";
+  const path = req.url ?? "/";
+
+  if (method === "GET" && path === "/healthz") {
+    sendJsonResponse(res, 200, { ok: true });
+    return;
+  }
+
+  if (method === "POST" && path === "/run") {
+    await drainRequest(req);
+    await handleRunRequest(res);
+    return;
+  }
+
+  await handleInvalidRequest(req, res, logRecord);
+});
+
+server.listen(port, () => {
+  logRecord({
+    severity: "INFO",
+    event: "mcp_probe.server_started",
+    target_url: config.targetUrl,
+    max_retries: config.maxRetries,
+    timeout_ms: config.timeoutMs,
+    backoff_ms: config.backoffMs,
+    min_tools: config.minTools,
+    timestamp: new Date().toISOString(),
+  });
+});
+
+async function handleRunRequest(res: ServerResponse): Promise<void> {
+  const result = await runProbe(config, {
+    clientFactory: createProbeClient,
+    log: logRecord,
+  });
+
+  sendJsonResponse(res, result.ok ? 200 : 500, result);
+}
+
+function createProbeClient(targetUrl: URL): ProbeClient {
+  const client = new Client(
+    {
+      name: "gcp-mcp-probe",
+      version: "1.0.0",
+    },
+    {
+      capabilities: {},
+    },
+  );
+  const transport = new StreamableHTTPClientTransport(targetUrl);
+
+  return {
+    connect: async () => {
+      await client.connect(transport);
+    },
+    listTools: async () => {
+      const result = await client.listTools();
+      return { tools: result.tools.map(tool => ({ name: tool.name })) };
+    },
+    close: async () => {
+      await client.close();
+    },
+  };
+}
+
+function resolvePort(value: string | undefined): number {
+  const resolvedValue = Number.parseInt(value ?? "8080", 10);
+  if (!Number.isInteger(resolvedValue) || resolvedValue <= 0) {
+    throw new Error("PORT must be a positive integer.");
+  }
+  return resolvedValue;
+}

--- a/monitoring/mcp-probe/src/index.ts
+++ b/monitoring/mcp-probe/src/index.ts
@@ -1,4 +1,4 @@
-import { createServer, type ServerResponse } from "node:http";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import {
@@ -23,7 +23,26 @@ const logRecord = (record: ProbeLogRecord): void => {
   process.stdout.write(payload);
 };
 
-const server = createServer(async (req, res) => {
+const server = createServer((req, res) => {
+  void handleRequest(req, res).catch(error => {
+    logUnhandledRequestError(error, req, res);
+  });
+});
+
+server.listen(port, () => {
+  logRecord({
+    severity: "INFO",
+    event: "mcp_probe.server_started",
+    target_url: config.targetUrl,
+    max_retries: config.maxRetries,
+    timeout_ms: config.timeoutMs,
+    backoff_ms: config.backoffMs,
+    min_tools: config.minTools,
+    timestamp: new Date().toISOString(),
+  });
+});
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
   const method = req.method ?? "GET";
   const path = req.url ?? "/";
 
@@ -39,20 +58,25 @@ const server = createServer(async (req, res) => {
   }
 
   await handleInvalidRequest(req, res, logRecord);
-});
+}
 
-server.listen(port, () => {
+function logUnhandledRequestError(error: unknown, req: IncomingMessage, res: ServerResponse): void {
   logRecord({
-    severity: "INFO",
-    event: "mcp_probe.server_started",
-    target_url: config.targetUrl,
-    max_retries: config.maxRetries,
-    timeout_ms: config.timeoutMs,
-    backoff_ms: config.backoffMs,
-    min_tools: config.minTools,
+    severity: "ERROR",
+    event: "mcp_probe.request_failed",
+    method: req.method,
+    path: req.url,
+    error_message: error instanceof Error ? error.message : String(error),
     timestamp: new Date().toISOString(),
   });
-});
+
+  if (!res.headersSent) {
+    sendJsonResponse(res, 500, { ok: false, error: "Internal server error" });
+    return;
+  }
+
+  res.end();
+}
 
 async function handleRunRequest(res: ServerResponse): Promise<void> {
   const result = await runProbe(config, {
@@ -90,7 +114,7 @@ function createProbeClient(targetUrl: URL): ProbeClient {
 }
 
 function resolvePort(value: string | undefined): number {
-  const resolvedValue = Number.parseInt(value ?? "8080", 10);
+  const resolvedValue = value === undefined ? 8080 : Number(value);
   if (!Number.isInteger(resolvedValue) || resolvedValue <= 0) {
     throw new Error("PORT must be a positive integer.");
   }

--- a/monitoring/mcp-probe/src/probe.ts
+++ b/monitoring/mcp-probe/src/probe.ts
@@ -56,7 +56,8 @@ export type ProbeLogRecord = {
     | "mcp_probe.attempt_failed"
     | "mcp_probe.hard_failure"
     | "mcp_probe.close_failed"
-    | "mcp_probe.invalid_request";
+    | "mcp_probe.invalid_request"
+    | "mcp_probe.request_failed";
   readonly target_url?: string;
   readonly attempt?: number;
   readonly attempts?: number;
@@ -185,8 +186,9 @@ export async function runProbe(config: ProbeConfig, dependencies: ProbeDependenc
         throw new ProbeValidationError(`Expected at least ${config.minTools} tool(s), received ${toolCount}.`);
       }
 
-      const totalLatencyMs = now() - startedAt;
-      const latencyMs = now() - attemptStartedAt;
+      const attemptEndedAt = now();
+      const totalLatencyMs = attemptEndedAt - startedAt;
+      const latencyMs = attemptEndedAt - attemptStartedAt;
       log({
         severity: "INFO",
         event: "mcp_probe.success",
@@ -319,7 +321,7 @@ function resolveRequiredUrl(value: string, field: string): string {
 }
 
 function resolvePositiveInteger(value: string | undefined, fallback: number, field: string): number {
-  const resolvedValue = value === undefined ? fallback : Number.parseInt(value, 10);
+  const resolvedValue = value === undefined ? fallback : Number(value);
   if (!Number.isInteger(resolvedValue) || resolvedValue <= 0) {
     throw new ProbeConfigurationError(`${field} must be a positive integer.`);
   }

--- a/monitoring/mcp-probe/src/probe.ts
+++ b/monitoring/mcp-probe/src/probe.ts
@@ -1,0 +1,347 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+/**
+ * Configuration for a single MCP probe execution.
+ */
+export type ProbeConfig = {
+  /** Target MCP endpoint URL. */
+  readonly targetUrl: string;
+  /** Number of total attempts before the probe is considered failed. */
+  readonly maxRetries: number;
+  /** Timeout applied independently to connect and listTools calls. */
+  readonly timeoutMs: number;
+  /** Base delay between retries. Each retry waits `backoffMs * attempt`. */
+  readonly backoffMs: number;
+  /** Minimum number of tools expected from the MCP server. */
+  readonly minTools: number;
+};
+
+/**
+ * Lightweight tool shape returned by the MCP SDK.
+ */
+export type ProbeTool = {
+  readonly name: string;
+};
+
+/**
+ * Result returned by a probe client's `listTools` call.
+ */
+export type ProbeListToolsResult = {
+  readonly tools: readonly ProbeTool[];
+};
+
+/**
+ * Minimal MCP client contract required by the probe runner.
+ */
+export type ProbeClient = {
+  connect: () => Promise<void>;
+  listTools: () => Promise<ProbeListToolsResult>;
+  close: () => Promise<void>;
+};
+
+/**
+ * Creates a probe client for the target MCP endpoint.
+ */
+export type ProbeClientFactory = (targetUrl: URL) => ProbeClient;
+
+/**
+ * Structured log record emitted by the probe runner.
+ */
+export type ProbeLogRecord = {
+  readonly severity: "INFO" | "WARNING" | "ERROR";
+  readonly event:
+    | "mcp_probe.server_started"
+    | "mcp_probe.started"
+    | "mcp_probe.success"
+    | "mcp_probe.attempt_failed"
+    | "mcp_probe.hard_failure"
+    | "mcp_probe.close_failed"
+    | "mcp_probe.invalid_request";
+  readonly target_url?: string;
+  readonly attempt?: number;
+  readonly attempts?: number;
+  readonly max_retries?: number;
+  readonly timeout_ms?: number;
+  readonly backoff_ms?: number;
+  readonly min_tools?: number;
+  readonly tool_count?: number;
+  readonly latency_ms?: number;
+  readonly error_message?: string;
+  readonly method?: string;
+  readonly path?: string;
+  readonly timestamp: string;
+};
+
+/**
+ * Success payload returned by the probe runner.
+ */
+export type ProbeSuccess = {
+  readonly ok: true;
+  readonly targetUrl: string;
+  readonly attempts: number;
+  readonly toolCount: number;
+  readonly totalLatencyMs: number;
+};
+
+/**
+ * Failure payload returned by the probe runner.
+ */
+export type ProbeFailure = {
+  readonly ok: false;
+  readonly targetUrl: string;
+  readonly attempts: number;
+  readonly totalLatencyMs: number;
+  readonly error: string;
+};
+
+/**
+ * Result payload returned by the probe runner.
+ */
+export type ProbeResult = ProbeSuccess | ProbeFailure;
+
+/**
+ * Dependencies injected into the probe runner for testability.
+ */
+export type ProbeDependencies = {
+  readonly clientFactory: ProbeClientFactory;
+  readonly sleep?: (ms: number) => Promise<void>;
+  readonly now?: () => number;
+  readonly timestamp?: () => string;
+  readonly log?: (record: ProbeLogRecord) => void;
+};
+
+/**
+ * Thrown when probe configuration is invalid.
+ */
+export class ProbeConfigurationError extends Error {
+  name = "ProbeConfigurationError";
+}
+
+/**
+ * Thrown when the MCP endpoint returns an unexpected tool list.
+ */
+export class ProbeValidationError extends Error {
+  name = "ProbeValidationError";
+}
+
+/**
+ * Resolves probe configuration from environment variables.
+ *
+ * @param env - Environment variables provided to the process.
+ * @return Validated probe configuration.
+ * @throws {ProbeConfigurationError} When any value is missing or invalid.
+ */
+export function resolveProbeConfig(env: NodeJS.ProcessEnv): ProbeConfig {
+  return {
+    targetUrl: resolveRequiredUrl(env.MCP_PROBE_TARGET_URL ?? "https://mcp.solana.com/mcp", "MCP_PROBE_TARGET_URL"),
+    maxRetries: resolvePositiveInteger(env.MCP_PROBE_MAX_RETRIES, 3, "MCP_PROBE_MAX_RETRIES"),
+    timeoutMs: resolvePositiveInteger(env.MCP_PROBE_TIMEOUT_MS, 10000, "MCP_PROBE_TIMEOUT_MS"),
+    backoffMs: resolvePositiveInteger(env.MCP_PROBE_BACKOFF_MS, 5000, "MCP_PROBE_BACKOFF_MS"),
+    minTools: resolvePositiveInteger(env.MCP_PROBE_MIN_TOOLS, 1, "MCP_PROBE_MIN_TOOLS"),
+  };
+}
+
+/**
+ * Executes the MCP probe with retries and structured logging.
+ *
+ * @param config - Probe runtime configuration.
+ * @param dependencies - External dependencies for client creation and timing.
+ * @return Probe result indicating success or failure.
+ */
+export async function runProbe(config: ProbeConfig, dependencies: ProbeDependencies): Promise<ProbeResult> {
+  const sleep = dependencies.sleep ?? defaultSleep;
+  const now = dependencies.now ?? Date.now;
+  const timestamp = dependencies.timestamp ?? (() => new Date().toISOString());
+  const log = dependencies.log ?? (() => {});
+  const startedAt = now();
+  const targetUrl = new URL(config.targetUrl);
+  let lastErrorMessage = "Unknown probe failure";
+
+  log({
+    severity: "INFO",
+    event: "mcp_probe.started",
+    target_url: config.targetUrl,
+    max_retries: config.maxRetries,
+    timeout_ms: config.timeoutMs,
+    backoff_ms: config.backoffMs,
+    min_tools: config.minTools,
+    timestamp: timestamp(),
+  });
+
+  for (let attempt = 1; attempt <= config.maxRetries; attempt += 1) {
+    const attemptStartedAt = now();
+    const client = dependencies.clientFactory(targetUrl);
+
+    try {
+      await withTimeout(client.connect(), config.timeoutMs, `Connect timed out after ${config.timeoutMs}ms`);
+      const { tools } = await withTimeout(
+        client.listTools(),
+        config.timeoutMs,
+        `listTools timed out after ${config.timeoutMs}ms`,
+      );
+      const toolCount = tools.length;
+
+      if (toolCount < config.minTools) {
+        throw new ProbeValidationError(`Expected at least ${config.minTools} tool(s), received ${toolCount}.`);
+      }
+
+      const totalLatencyMs = now() - startedAt;
+      const latencyMs = now() - attemptStartedAt;
+      log({
+        severity: "INFO",
+        event: "mcp_probe.success",
+        target_url: config.targetUrl,
+        attempt,
+        attempts: attempt,
+        tool_count: toolCount,
+        latency_ms: latencyMs,
+        timestamp: timestamp(),
+      });
+
+      return {
+        ok: true,
+        targetUrl: config.targetUrl,
+        attempts: attempt,
+        toolCount,
+        totalLatencyMs,
+      };
+    } catch (error) {
+      lastErrorMessage = error instanceof Error ? error.message : String(error);
+      log({
+        severity: "WARNING",
+        event: "mcp_probe.attempt_failed",
+        target_url: config.targetUrl,
+        attempt,
+        max_retries: config.maxRetries,
+        error_message: lastErrorMessage,
+        latency_ms: now() - attemptStartedAt,
+        timestamp: timestamp(),
+      });
+    } finally {
+      try {
+        await client.close();
+      } catch (error) {
+        log({
+          severity: "WARNING",
+          event: "mcp_probe.close_failed",
+          target_url: config.targetUrl,
+          attempt,
+          error_message: error instanceof Error ? error.message : String(error),
+          timestamp: timestamp(),
+        });
+      }
+    }
+
+    if (attempt < config.maxRetries) {
+      await sleep(config.backoffMs * attempt);
+    }
+  }
+
+  const totalLatencyMs = now() - startedAt;
+  log({
+    severity: "ERROR",
+    event: "mcp_probe.hard_failure",
+    target_url: config.targetUrl,
+    attempts: config.maxRetries,
+    error_message: lastErrorMessage,
+    latency_ms: totalLatencyMs,
+    timestamp: timestamp(),
+  });
+
+  return {
+    ok: false,
+    targetUrl: config.targetUrl,
+    attempts: config.maxRetries,
+    totalLatencyMs,
+    error: lastErrorMessage,
+  };
+}
+
+/**
+ * Writes a JSON response to the HTTP server.
+ *
+ * @param res - Node HTTP response.
+ * @param statusCode - HTTP status code.
+ * @param body - JSON body to serialize.
+ */
+export function sendJsonResponse(res: ServerResponse, statusCode: number, body: Record<string, unknown>): void {
+  const payload = JSON.stringify(body);
+  res.statusCode = statusCode;
+  res.setHeader("content-type", "application/json; charset=utf-8");
+  res.setHeader("content-length", Buffer.byteLength(payload));
+  res.end(payload);
+}
+
+/**
+ * Reads and discards a request body so the connection can be cleanly reused.
+ *
+ * @param req - Incoming Node HTTP request.
+ */
+export async function drainRequest(req: IncomingMessage): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    req.on("error", reject);
+    req.on("data", () => {
+      // Intentionally ignored.
+    });
+    req.on("end", resolve);
+  });
+}
+
+/**
+ * Returns a structured invalid-request response and emits a log record.
+ *
+ * @param req - Incoming request that could not be served.
+ * @param res - Outgoing response object.
+ * @param log - Log sink.
+ */
+export async function handleInvalidRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  log: (record: ProbeLogRecord) => void,
+): Promise<void> {
+  await drainRequest(req);
+  log({
+    severity: "WARNING",
+    event: "mcp_probe.invalid_request",
+    method: req.method,
+    path: req.url,
+    timestamp: new Date().toISOString(),
+  });
+  sendJsonResponse(res, 404, { ok: false, error: "Not found" });
+}
+
+function resolveRequiredUrl(value: string, field: string): string {
+  try {
+    return new URL(value).toString();
+  } catch {
+    throw new ProbeConfigurationError(`${field} must be a valid URL.`);
+  }
+}
+
+function resolvePositiveInteger(value: string | undefined, fallback: number, field: string): number {
+  const resolvedValue = value === undefined ? fallback : Number.parseInt(value, 10);
+  if (!Number.isInteger(resolvedValue) || resolvedValue <= 0) {
+    throw new ProbeConfigurationError(`${field} must be a positive integer.`);
+  }
+  return resolvedValue;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, errorMessage: string): Promise<T> {
+  let timeoutId: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error(errorMessage)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/monitoring/mcp-probe/tsconfig.json
+++ b/monitoring/mcp-probe/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tests/unit/monitoring/mcp-probe.test.ts
+++ b/tests/unit/monitoring/mcp-probe.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ProbeConfigurationError,
+  ProbeValidationError,
+  resolveProbeConfig,
+  runProbe,
+  type ProbeClient,
+  type ProbeClientFactory,
+  type ProbeLogRecord,
+  type ProbeResult,
+} from "../../../monitoring/mcp-probe/src/probe.js";
+
+describe("resolveProbeConfig", () => {
+  it("returns defaults when optional environment variables are unset", () => {
+    const config = resolveProbeConfig({});
+
+    expect(config).toEqual({
+      targetUrl: "https://mcp.solana.com/mcp",
+      maxRetries: 3,
+      timeoutMs: 10000,
+      backoffMs: 5000,
+      minTools: 1,
+    });
+  });
+
+  it("throws when a numeric environment variable is invalid", () => {
+    expect(() => resolveProbeConfig({ MCP_PROBE_MAX_RETRIES: "0" })).toThrow(ProbeConfigurationError);
+  });
+});
+
+describe("runProbe", () => {
+  it("returns success on the first healthy attempt", async () => {
+    const clientFactory = createClientFactory([
+      {
+        connect: vi.fn().mockResolvedValue(undefined),
+        listTools: vi.fn().mockResolvedValue({ tools: [{ name: "tool-a" }, { name: "tool-b" }] }),
+        close: vi.fn().mockResolvedValue(undefined),
+      },
+    ]);
+    const log = vi.fn<(record: ProbeLogRecord) => void>();
+    const now = createNowMock([0, 5, 10, 15]);
+
+    const result = await runProbe(
+      {
+        targetUrl: "https://mcp.solana.com/mcp",
+        maxRetries: 3,
+        timeoutMs: 1000,
+        backoffMs: 10,
+        minTools: 1,
+      },
+      { clientFactory, log, now },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      targetUrl: "https://mcp.solana.com/mcp",
+      attempts: 1,
+      toolCount: 2,
+      totalLatencyMs: 10,
+    });
+    expect(log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "mcp_probe.success",
+        attempt: 1,
+        tool_count: 2,
+      }),
+    );
+  });
+
+  it("retries after a failed attempt and eventually succeeds", async () => {
+    const firstClient: ProbeClient = {
+      connect: vi.fn().mockRejectedValue(new Error("socket hang up")),
+      listTools: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const secondClient: ProbeClient = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      listTools: vi.fn().mockResolvedValue({ tools: [{ name: "tool-a" }] }),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    const clientFactory = createClientFactory([firstClient, secondClient]);
+    const log = vi.fn<(record: ProbeLogRecord) => void>();
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const now = createNowMock([0, 5, 10, 25, 35, 50]);
+
+    const result = await runProbe(
+      {
+        targetUrl: "https://mcp.solana.com/mcp",
+        maxRetries: 3,
+        timeoutMs: 1000,
+        backoffMs: 10,
+        minTools: 1,
+      },
+      { clientFactory, log, sleep, now },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      targetUrl: "https://mcp.solana.com/mcp",
+      attempts: 2,
+      toolCount: 1,
+      totalLatencyMs: 35,
+    });
+    expect(sleep).toHaveBeenCalledWith(10);
+    expect(log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "mcp_probe.attempt_failed",
+        attempt: 1,
+        error_message: "socket hang up",
+      }),
+    );
+  });
+
+  it("fails after exhausting all retries", async () => {
+    const clientFactory = createClientFactory([
+      {
+        connect: vi.fn().mockResolvedValue(undefined),
+        listTools: vi.fn().mockResolvedValue({ tools: [] }),
+        close: vi.fn().mockResolvedValue(undefined),
+      },
+      {
+        connect: vi.fn().mockRejectedValue(new Error("transport offline")),
+        listTools: vi.fn(),
+        close: vi.fn().mockResolvedValue(undefined),
+      },
+    ]);
+    const log = vi.fn<(record: ProbeLogRecord) => void>();
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const now = createNowMock([0, 5, 10, 20, 30, 45, 55]);
+
+    const result = await runProbe(
+      {
+        targetUrl: "https://mcp.solana.com/mcp",
+        maxRetries: 2,
+        timeoutMs: 1000,
+        backoffMs: 10,
+        minTools: 1,
+      },
+      { clientFactory, log, sleep, now },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      targetUrl: "https://mcp.solana.com/mcp",
+      attempts: 2,
+      totalLatencyMs: 45,
+      error: "transport offline",
+    });
+    expect(log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "mcp_probe.hard_failure",
+        attempts: 2,
+        error_message: "transport offline",
+      }),
+    );
+  });
+
+  it("treats too few tools as a validation failure", async () => {
+    const clientFactory = createClientFactory([
+      {
+        connect: vi.fn().mockResolvedValue(undefined),
+        listTools: vi.fn().mockResolvedValue({ tools: [] }),
+        close: vi.fn().mockResolvedValue(undefined),
+      },
+    ]);
+
+    const result = await runProbe(
+      {
+        targetUrl: "https://mcp.solana.com/mcp",
+        maxRetries: 1,
+        timeoutMs: 1000,
+        backoffMs: 10,
+        minTools: 1,
+      },
+      {
+        clientFactory,
+        now: createNowMock([0, 5, 10, 15]),
+      },
+    );
+
+    assertFailureResult(result);
+    expect(typeof result.error).toBe("string");
+    expect(result.error).toContain("Expected at least 1 tool");
+  });
+
+  it("logs close failures without failing a successful probe", async () => {
+    const clientFactory = createClientFactory([
+      {
+        connect: vi.fn().mockResolvedValue(undefined),
+        listTools: vi.fn().mockResolvedValue({ tools: [{ name: "tool-a" }] }),
+        close: vi.fn().mockRejectedValue(new Error("close failed")),
+      },
+    ]);
+    const log = vi.fn<(record: ProbeLogRecord) => void>();
+
+    const result = await runProbe(
+      {
+        targetUrl: "https://mcp.solana.com/mcp",
+        maxRetries: 1,
+        timeoutMs: 1000,
+        backoffMs: 10,
+        minTools: 1,
+      },
+      {
+        clientFactory,
+        log,
+        now: createNowMock([0, 5, 10, 15]),
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "mcp_probe.close_failed",
+        error_message: "close failed",
+      }),
+    );
+  });
+
+  it("uses a validation error when the returned tool count is below the threshold", async () => {
+    const clientFactory = createClientFactory([
+      {
+        connect: vi.fn().mockResolvedValue(undefined),
+        listTools: vi.fn().mockResolvedValue({ tools: [] }),
+        close: vi.fn().mockResolvedValue(undefined),
+      },
+    ]);
+
+    const result = await runProbe(
+      {
+        targetUrl: "https://mcp.solana.com/mcp",
+        maxRetries: 1,
+        timeoutMs: 1000,
+        backoffMs: 10,
+        minTools: 1,
+      },
+      {
+        clientFactory,
+        now: createNowMock([0, 5, 10, 15]),
+      },
+    );
+
+    assertFailureResult(result);
+    expect(() => {
+      throw new ProbeValidationError(result.error);
+    }).toThrow(ProbeValidationError);
+  });
+});
+
+function assertFailureResult(result: ProbeResult): asserts result is Extract<ProbeResult, { ok: false }> {
+  if (result.ok) {
+    throw new Error("Expected failure result.");
+  }
+}
+
+function createClientFactory(clients: ProbeClient[]): ProbeClientFactory {
+  let index = 0;
+  return () => {
+    const client = clients[index];
+    index += 1;
+    if (!client) {
+      throw new Error("No client stub left for this attempt.");
+    }
+    return client;
+  };
+}
+
+function createNowMock(values: number[]): () => number {
+  let index = 0;
+  return () => {
+    const value = values[index];
+    index += 1;
+    if (value === undefined) {
+      throw new Error("Ran out of mocked time values.");
+    }
+    return value;
+  };
+}

--- a/tests/unit/monitoring/mcp-probe.test.ts
+++ b/tests/unit/monitoring/mcp-probe.test.ts
@@ -1,14 +1,30 @@
-import { describe, expect, it, vi } from "vitest";
-import {
-  ProbeConfigurationError,
-  ProbeValidationError,
-  resolveProbeConfig,
-  runProbe,
-  type ProbeClient,
-  type ProbeClientFactory,
-  type ProbeLogRecord,
-  type ProbeResult,
-} from "../../../monitoring/mcp-probe/src/probe.js";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+type ProbeModule = typeof import("../../../monitoring/mcp-probe/src/probe.js", {
+  with: { "resolution-mode": "import" },
+});
+type ProbeClient = import("../../../monitoring/mcp-probe/src/probe.js", {
+  with: { "resolution-mode": "import" },
+}).ProbeClient;
+type ProbeClientFactory = import("../../../monitoring/mcp-probe/src/probe.js", {
+  with: { "resolution-mode": "import" },
+}).ProbeClientFactory;
+type ProbeLogRecord = import("../../../monitoring/mcp-probe/src/probe.js", {
+  with: { "resolution-mode": "import" },
+}).ProbeLogRecord;
+type ProbeResult = import("../../../monitoring/mcp-probe/src/probe.js", {
+  with: { "resolution-mode": "import" },
+}).ProbeResult;
+
+let ProbeConfigurationError: ProbeModule["ProbeConfigurationError"];
+let ProbeValidationError: ProbeModule["ProbeValidationError"];
+let resolveProbeConfig: ProbeModule["resolveProbeConfig"];
+let runProbe: ProbeModule["runProbe"];
+
+beforeAll(async () => {
+  const probeModule = await import("../../../monitoring/mcp-probe/src/probe.js");
+  ({ ProbeConfigurationError, ProbeValidationError, resolveProbeConfig, runProbe } = probeModule);
+});
 
 describe("resolveProbeConfig", () => {
   it("returns defaults when optional environment variables are unset", () => {

--- a/tests/unit/monitoring/mcp-probe.test.ts
+++ b/tests/unit/monitoring/mcp-probe.test.ts
@@ -1,3 +1,4 @@
+import { PassThrough } from "node:stream";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 type ProbeModule = typeof import("../../../monitoring/mcp-probe/src/probe.js", {
@@ -20,10 +21,11 @@ let ProbeConfigurationError: ProbeModule["ProbeConfigurationError"];
 let ProbeValidationError: ProbeModule["ProbeValidationError"];
 let resolveProbeConfig: ProbeModule["resolveProbeConfig"];
 let runProbe: ProbeModule["runProbe"];
+let handleInvalidRequest: ProbeModule["handleInvalidRequest"];
 
 beforeAll(async () => {
   const probeModule = await import("../../../monitoring/mcp-probe/src/probe.js");
-  ({ ProbeConfigurationError, ProbeValidationError, resolveProbeConfig, runProbe } = probeModule);
+  ({ ProbeConfigurationError, ProbeValidationError, resolveProbeConfig, runProbe, handleInvalidRequest } = probeModule);
 });
 
 describe("resolveProbeConfig", () => {
@@ -41,6 +43,7 @@ describe("resolveProbeConfig", () => {
 
   it("throws when a numeric environment variable is invalid", () => {
     expect(() => resolveProbeConfig({ MCP_PROBE_MAX_RETRIES: "0" })).toThrow(ProbeConfigurationError);
+    expect(() => resolveProbeConfig({ MCP_PROBE_MAX_RETRIES: "3ms" })).toThrow(ProbeConfigurationError);
   });
 });
 
@@ -79,6 +82,43 @@ describe("runProbe", () => {
         event: "mcp_probe.success",
         attempt: 1,
         tool_count: 2,
+      }),
+    );
+  });
+
+  it("returns consistent attempt and total latency values for a first-attempt success", async () => {
+    const clientFactory = createClientFactory([
+      {
+        connect: vi.fn().mockResolvedValue(undefined),
+        listTools: vi.fn().mockResolvedValue({ tools: [{ name: "tool-a" }] }),
+        close: vi.fn().mockResolvedValue(undefined),
+      },
+    ]);
+    const log = vi.fn<(record: ProbeLogRecord) => void>();
+    const now = createNowMock([0, 5, 10]);
+
+    const result = await runProbe(
+      {
+        targetUrl: "https://mcp.solana.com/mcp",
+        maxRetries: 1,
+        timeoutMs: 1000,
+        backoffMs: 10,
+        minTools: 1,
+      },
+      { clientFactory, log, now },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      targetUrl: "https://mcp.solana.com/mcp",
+      attempts: 1,
+      toolCount: 1,
+      totalLatencyMs: 10,
+    });
+    expect(log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "mcp_probe.success",
+        latency_ms: 5,
       }),
     );
   });
@@ -263,6 +303,32 @@ describe("runProbe", () => {
   });
 });
 
+describe("handleInvalidRequest", () => {
+  it("drains the request body, logs the event, and returns 404", async () => {
+    const log = vi.fn<(record: ProbeLogRecord) => void>();
+    const req = createMockRequest({ method: "GET", url: "/unknown" });
+    const res = createMockResponse();
+
+    queueMicrotask(() => {
+      req.write("ignored");
+      req.end();
+    });
+
+    await handleInvalidRequest(req as never as Parameters<typeof handleInvalidRequest>[0], res as never, log);
+
+    expect(log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "mcp_probe.invalid_request",
+        method: "GET",
+        path: "/unknown",
+      }),
+    );
+    expect(res.statusCode).toBe(404);
+    expect(res.headers.get("content-type")).toBe("application/json; charset=utf-8");
+    expect(JSON.parse(res.body)).toEqual({ ok: false, error: "Not found" });
+  });
+});
+
 function assertFailureResult(result: ProbeResult): asserts result is Extract<ProbeResult, { ok: false }> {
   if (result.ok) {
     throw new Error("Expected failure result.");
@@ -290,5 +356,40 @@ function createNowMock(values: number[]): () => number {
       throw new Error("Ran out of mocked time values.");
     }
     return value;
+  };
+}
+
+type MockResponse = {
+  statusCode: number;
+  headers: Map<string, string>;
+  body: string;
+  headersSent: boolean;
+  setHeader: (name: string, value: string) => void;
+  end: (chunk?: string) => void;
+};
+
+function createMockRequest(values: { method: string; url: string }): PassThrough & {
+  method: string;
+  url: string;
+} {
+  const stream = new PassThrough() as PassThrough & { method: string; url: string };
+  stream.method = values.method;
+  stream.url = values.url;
+  return stream;
+}
+
+function createMockResponse(): MockResponse {
+  return {
+    statusCode: 200,
+    headers: new Map<string, string>(),
+    body: "",
+    headersSent: false,
+    setHeader(name: string, value: string) {
+      this.headers.set(name, value);
+    },
+    end(chunk?: string) {
+      this.headersSent = true;
+      this.body = chunk ?? "";
+    },
   };
 }


### PR DESCRIPTION
## Summary
Add a standalone MCP probe service and test coverage so Google Cloud can monitor real MCP health and alert on repeated failures.

## Context
The production MCP endpoint can be reachable while still failing protocol-level requests, so root uptime checks were not sufficient. This change adds a small monitoring service that performs the same kind of MCP `listTools()` check used in the existing test strategy, making alerting reflect actual MCP availability rather than just HTTP reachability.

## Changes
- add a dedicated `monitoring/mcp-probe` Cloud Run service with `/healthz` and `/run` endpoints
- implement configurable MCP probe execution with retries, timeouts, structured logging, and hard-failure events
- add unit tests covering successful probes, retries, validation failures, hard failures, and close failures

### Key Implementation Details
The probe builds a real MCP client against the configured target URL and calls `listTools()` to validate the server response. It emits structured log events like `mcp_probe.success` and `mcp_probe.hard_failure`, which can be used by Cloud Logging metrics and Monitoring alerts. Retry, timeout, backoff, and minimum tool count thresholds are all configurable via environment variables.

## Use Cases
- detect when the hosted MCP is serving traffic but failing actual MCP calls
- alert only after repeated probe failures rather than on a single transient error
- support external monitoring from Google Cloud without coupling alert logic to the main Vercel deployment

## Testing
- `pnpm vitest run tests/unit/monitoring/mcp-probe.test.ts`
- `pnpm eslint monitoring/mcp-probe/src tests/unit/monitoring/mcp-probe.test.ts`
- `pnpm tsc --noEmit -p monitoring/mcp-probe/tsconfig.json`
