### PR TITLE
feat(inspect_entity): moved initial inspect_entity functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .vercel
 node_modules/
 .env
+.env.*
+!.env.example
 dist/
 coverage/
 .pnpm-store/
+.mcp.json

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,27 +6,28 @@ import { resources } from "./resources";
 import { solanaEcosystemTools } from "./tools/ecosystemSolanaTools";
 import { SolanaTool } from "./tools/types";
 import { createSolanaTools } from "./tools/generalSolanaTools";
+import { inspectEntityTools } from "./tools/inspectEntityTools";
 import { inkeepRagModel } from "./services/inkeep";
 
 export function createMcp() {
   return createMcpHandler(
     (server: McpServer) => {
       ([] as SolanaTool[])
-        .concat(createSolanaTools(inkeepRagModel), solanaEcosystemTools)
+        .concat(createSolanaTools(inkeepRagModel), solanaEcosystemTools, inspectEntityTools)
         .forEach((tool: SolanaTool) => {
-          if (tool.outputSchema) {
+          if (tool.outputSchema || tool.annotations) {
             server.registerTool(
               tool.title,
               {
                 description: tool.description ?? "",
                 inputSchema: tool.parameters,
-                outputSchema: tool.outputSchema,
-                annotations: {},
+                ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
+                annotations: tool.annotations ?? {},
               },
               tool.func,
             );
           } else {
-            server.tool(tool.title, tool.description ?? "", tool.parameters, tool.func);
+            server.tool(tool.title, tool.description ?? "", tool.parameters as z.ZodRawShape, tool.func);
           }
         });
 

--- a/lib/solana/account-kinds/bpf-loader.ts
+++ b/lib/solana/account-kinds/bpf-loader.ts
@@ -1,18 +1,6 @@
-import { BPF_LOADER_PROGRAM_ID, BPF_LOADER_2_PROGRAM_ID, TOKEN_2022_PROGRAM_ADDRESS } from "../constants";
+import { BPF_LOADER_PROGRAM_ID, BPF_LOADER_2_PROGRAM_ID } from "../constants";
 import type { NormalizedAccountInfo } from "../types";
-import { unknownMarker, type AccountKindBuilder } from "./shared";
-
-const PROGRAM_ADDRESS_LABELS: Record<string, string> = {
-  [TOKEN_2022_PROGRAM_ADDRESS]: "Token-2022 Program",
-  Vote111111111111111111111111111111111111111: "Vote Program",
-};
-
-function resolveProgramAddressLabel(address: string | undefined): string | null {
-  if (!address) {
-    return null;
-  }
-  return PROGRAM_ADDRESS_LABELS[address] ?? null;
-}
+import { resolveProgramAddressLabel, unknownMarker, type AccountKindBuilder } from "./shared";
 
 function buildBpfLoaderOverviewFields(account: NormalizedAccountInfo): Record<string, unknown> {
   return {

--- a/lib/solana/account-kinds/bpf-upgradeable-loader.ts
+++ b/lib/solana/account-kinds/bpf-upgradeable-loader.ts
@@ -1,18 +1,6 @@
-import { BPF_UPGRADEABLE_LOADER_PROGRAM_ID, TOKEN_2022_PROGRAM_ADDRESS } from "../constants";
+import { BPF_UPGRADEABLE_LOADER_PROGRAM_ID } from "../constants";
 import type { NormalizedAccountInfo } from "../types";
-import { unknownMarker, type AccountKindBuilder } from "./shared";
-
-const PROGRAM_ADDRESS_LABELS: Record<string, string> = {
-  [TOKEN_2022_PROGRAM_ADDRESS]: "Token-2022 Program",
-  Vote111111111111111111111111111111111111111: "Vote Program",
-};
-
-function resolveProgramAddressLabel(address: string | undefined): string | null {
-  if (!address) {
-    return null;
-  }
-  return PROGRAM_ADDRESS_LABELS[address] ?? null;
-}
+import { resolveProgramAddressLabel, unknownMarker, type AccountKindBuilder } from "./shared";
 
 function buildUpgradeableLoaderOverviewFields(account: NormalizedAccountInfo): Record<string, unknown> {
   const fields: Record<string, unknown> = {

--- a/lib/solana/account-kinds/loader.ts
+++ b/lib/solana/account-kinds/loader.ts
@@ -1,18 +1,6 @@
-import { LOADER_V4_PROGRAM_ID, TOKEN_2022_PROGRAM_ADDRESS } from "../constants";
+import { LOADER_V4_PROGRAM_ID } from "../constants";
 import type { NormalizedAccountInfo } from "../types";
-import { unknownMarker, type AccountKindBuilder } from "./shared";
-
-const PROGRAM_ADDRESS_LABELS: Record<string, string> = {
-  [TOKEN_2022_PROGRAM_ADDRESS]: "Token-2022 Program",
-  Vote111111111111111111111111111111111111111: "Vote Program",
-};
-
-function resolveProgramAddressLabel(address: string | undefined): string | null {
-  if (!address) {
-    return null;
-  }
-  return PROGRAM_ADDRESS_LABELS[address] ?? null;
-}
+import { resolveProgramAddressLabel, unknownMarker, type AccountKindBuilder } from "./shared";
 
 function buildLoaderOverviewFields(account: NormalizedAccountInfo): Record<string, unknown> {
   return {

--- a/lib/solana/account-kinds/shared.ts
+++ b/lib/solana/account-kinds/shared.ts
@@ -1,5 +1,18 @@
-import type { AccountPayloadContext, AccountEntityKind, NormalizedAccountInfo } from "../types";
+import { TOKEN_2022_PROGRAM_ADDRESS } from "../constants";
+import type { AccountPayloadContext, AccountEntityKind, MetaplexMetadataResult, NormalizedAccountInfo } from "../types";
 import { asBoolean, asSafeNumeric, asRecord, asString } from "../parse-helpers";
+
+const PROGRAM_ADDRESS_LABELS: Record<string, string> = {
+  [TOKEN_2022_PROGRAM_ADDRESS]: "Token-2022 Program",
+  Vote111111111111111111111111111111111111111: "Vote Program",
+};
+
+export function resolveProgramAddressLabel(address: string | undefined): string | null {
+  if (!address) {
+    return null;
+  }
+  return PROGRAM_ADDRESS_LABELS[address] ?? null;
+}
 
 export type AccountKindBuilder = (context: AccountPayloadContext) => Record<string, unknown>;
 
@@ -86,6 +99,27 @@ export function buildMintOverviewFields(account: NormalizedAccountInfo): Record<
   }
 
   return fields;
+}
+
+export function buildMetaplexMetadataField(result: MetaplexMetadataResult | undefined): Record<string, unknown> | null {
+  if (!result || result.status === "not_found") {
+    return null;
+  }
+  if (result.status === "unknown") {
+    return unknownMarker(result.reason);
+  }
+  return {
+    name: result.name,
+    symbol: result.symbol,
+    uri: result.uri,
+    seller_fee_basis_points: result.seller_fee_basis_points,
+    creators: result.creators,
+    token_standard: result.token_standard,
+    collection: result.collection,
+    is_collection: result.is_collection,
+    primary_sale_happened: result.primary_sale_happened,
+    is_mutable: result.is_mutable,
+  };
 }
 
 export function buildSplMultisigFields(account: NormalizedAccountInfo): Record<string, unknown> {

--- a/lib/solana/account-kinds/spl-token-2022-mint.ts
+++ b/lib/solana/account-kinds/spl-token-2022-mint.ts
@@ -1,6 +1,6 @@
 import { asRecord, asString } from "../parse-helpers";
 import type { NormalizedAccountInfo } from "../types";
-import { buildMintOverviewFields, type AccountKindBuilder } from "./shared";
+import { buildMetaplexMetadataField, buildMintOverviewFields, type AccountKindBuilder } from "./shared";
 
 function extractExtensions(account: NormalizedAccountInfo): unknown[] | null {
   const parsedInfo = asRecord(asRecord(account.parsedData)?.info);
@@ -28,6 +28,7 @@ export const buildSplToken2022MintPayload: AccountKindBuilder = context => {
       kind: context.kind,
       ...buildMintOverviewFields(context.account),
       extensions: extractExtensions(context.account),
+      metaplex_metadata: buildMetaplexMetadataField(context.metaplexMetadataResult),
     },
   };
 };

--- a/lib/solana/account-kinds/spl-token-mint.ts
+++ b/lib/solana/account-kinds/spl-token-mint.ts
@@ -1,10 +1,11 @@
-import { buildMintOverviewFields, type AccountKindBuilder } from "./shared";
+import { buildMetaplexMetadataField, buildMintOverviewFields, type AccountKindBuilder } from "./shared";
 
 export const buildSplTokenMintPayload: AccountKindBuilder = context => {
   return {
     entity: {
       kind: context.kind,
       ...buildMintOverviewFields(context.account),
+      metaplex_metadata: buildMetaplexMetadataField(context.metaplexMetadataResult),
     },
   };
 };

--- a/lib/solana/constants.ts
+++ b/lib/solana/constants.ts
@@ -32,3 +32,4 @@ export type SupportedCluster = (typeof SUPPORTED_CLUSTERS)[number];
 
 export const RPC_REQUEST_TIMEOUT_MS = 5000;
 export const DAS_REQUEST_TIMEOUT_MS = 3000;
+export const METAPLEX_METADATA_TIMEOUT_MS = 3000;

--- a/lib/solana/inspect-entity.ts
+++ b/lib/solana/inspect-entity.ts
@@ -1,0 +1,288 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
+import { unknownMarker } from "./account-kinds/shared";
+import { buildAccountPayloadWithRouter as buildAccountPayload } from "./inspect-entity-account-router";
+import {
+  classifyAccountKindBase,
+  decodeIdentifierKind,
+  normalizeDasOutcome,
+  promoteAccountKindWithDas,
+} from "./inspect-entity-classifier";
+import type {
+  DasClassificationOutcome,
+  IdlDiscoveryResult,
+  MetaplexMetadataResult,
+  MultisigReferenceResult,
+  SecurityMetadataResult,
+  VerificationResult,
+} from "./types";
+import { resolveMetaplexMetadata } from "./metaplex-metadata";
+import { fetchAccountInfo, fetchAsset, fetchSignatureStatus, fetchTransaction, isSourceUnavailableError } from "./rpc";
+import { SUPPORTED_CLUSTERS, type SupportedCluster } from "./constants";
+import {
+  currentlyUnsupported,
+  internalError,
+  invalidArgument,
+  notFound,
+  sanitizeToolError,
+  toToolResult,
+} from "./errors";
+import { enrichUpgradeableProgramData, normalizeAccountProbe } from "./account-normalizer";
+import { logger } from "../observability/logger";
+
+export const inspectEntityInputSchema = z
+  .object({
+    identifier: z.string().min(1).max(128),
+    cluster: z.enum(SUPPORTED_CLUSTERS).optional().default("mainnet-beta"),
+  })
+  .strict();
+
+type InspectEntityArgs = z.infer<typeof inspectEntityInputSchema>;
+
+type InspectEntityDependencies = {
+  fetchAccountInfo: typeof fetchAccountInfo;
+  fetchTransaction: typeof fetchTransaction;
+  fetchAsset: typeof fetchAsset;
+  resolveProgramVerification: (
+    programAddress: string,
+    programAuthority: string | null,
+    programDataBase64: string | null,
+    cluster: SupportedCluster,
+  ) => Promise<VerificationResult>;
+  resolveProgramSecurityMetadata: (
+    programAddress: string,
+    programDataRawBase64: string | null,
+    cluster: SupportedCluster,
+  ) => Promise<SecurityMetadataResult>;
+  resolveMultisigReference: (
+    upgradeAuthority: string | null,
+    cluster: SupportedCluster,
+  ) => Promise<MultisigReferenceResult>;
+  resolveProgramIdl: (programAddress: string, cluster: SupportedCluster) => Promise<IdlDiscoveryResult>;
+  resolveMetaplexMetadata: (mintAddress: string, cluster: SupportedCluster) => Promise<MetaplexMetadataResult>;
+  fetchSignatureStatus: typeof fetchSignatureStatus;
+};
+
+// Enrichment resolvers stubbed until Steps 5-6 port the real implementations.
+const defaultDependencies: InspectEntityDependencies = {
+  fetchAccountInfo,
+  fetchTransaction,
+  fetchAsset,
+  resolveProgramVerification: async () => ({ status: "unverified" as const }),
+  resolveProgramSecurityMetadata: async () => ({ status: "missing" as const }),
+  resolveMultisigReference: async () => ({ status: "not_multisig" as const }),
+  resolveProgramIdl: async () => ({ status: "not_found" as const }),
+  resolveMetaplexMetadata,
+  fetchSignatureStatus,
+};
+
+function toSourceUnavailablePayload(kind: "account" | "transaction"): Record<string, unknown> {
+  return {
+    entity: {
+      kind,
+      source: unknownMarker("source_unavailable"),
+    },
+  };
+}
+
+function toNotFoundPayload(kind: "account" | "transaction"): Record<string, unknown> {
+  return {
+    entity: {
+      kind,
+    },
+  };
+}
+
+async function resolveAccount(
+  identifier: string,
+  cluster: SupportedCluster,
+  dependencies: InspectEntityDependencies,
+): Promise<CallToolResult> {
+  try {
+    const accountProbe = await dependencies.fetchAccountInfo(identifier, cluster);
+    const normalizedAccount = normalizeAccountProbe(identifier, accountProbe);
+
+    if (normalizedAccount === null) {
+      return toToolResult({
+        payload: toNotFoundPayload("account"),
+        errors: [notFound()],
+      });
+    }
+
+    const enrichedAccount = await enrichUpgradeableProgramData(
+      normalizedAccount,
+      cluster,
+      dependencies.fetchAccountInfo,
+    );
+
+    const baseKind = classifyAccountKindBase(enrichedAccount);
+
+    let verificationResult: VerificationResult | undefined;
+    let securityMetadataResult: SecurityMetadataResult | undefined;
+    let multisigReferenceResult: MultisigReferenceResult | undefined;
+    let idlDiscoveryResult: IdlDiscoveryResult | undefined;
+
+    if (baseKind === "bpf-upgradeable-loader") {
+      [verificationResult, securityMetadataResult, multisigReferenceResult, idlDiscoveryResult] = await Promise.all([
+        dependencies
+          .resolveProgramVerification(
+            identifier,
+            enrichedAccount.programData?.authority ?? null,
+            enrichedAccount.programDataRawBase64 ?? null,
+            cluster,
+          )
+          .catch((error): VerificationResult => {
+            logger.warn({
+              event: "inspect_entity.safety_catch",
+              resolver: "verification",
+              identifier,
+              error,
+            });
+            return { status: "unknown", reason: "source_unavailable" };
+          }),
+        dependencies
+          .resolveProgramSecurityMetadata(identifier, enrichedAccount.programDataRawBase64 ?? null, cluster)
+          .catch((error): SecurityMetadataResult => {
+            logger.warn({
+              event: "inspect_entity.safety_catch",
+              resolver: "security_metadata",
+              identifier,
+              error,
+            });
+            return { status: "unknown", reason: "source_unavailable" };
+          }),
+        dependencies
+          .resolveMultisigReference(enrichedAccount.programData?.authority ?? null, cluster)
+          .catch((error): MultisigReferenceResult => {
+            logger.warn({
+              event: "inspect_entity.safety_catch",
+              resolver: "multisig",
+              identifier,
+              error,
+            });
+            return { status: "unknown", reason: "source_unavailable" };
+          }),
+        dependencies.resolveProgramIdl(identifier, cluster).catch((error): IdlDiscoveryResult => {
+          logger.warn({
+            event: "inspect_entity.safety_catch",
+            resolver: "idl",
+            identifier,
+            error,
+          });
+          return { status: "unknown", reason: "source_unavailable" };
+        }),
+      ]);
+    }
+
+    let dasOutcome: DasClassificationOutcome | null = null;
+
+    if (baseKind === "unknown") {
+      try {
+        const rawAsset = await dependencies.fetchAsset(identifier, cluster);
+        dasOutcome = normalizeDasOutcome(rawAsset);
+      } catch (error) {
+        logger.warn({
+          event: "inspect_entity.safety_catch",
+          resolver: "das",
+          identifier,
+          error,
+        });
+        dasOutcome = null;
+      }
+    }
+
+    const finalKind = promoteAccountKindWithDas(baseKind, dasOutcome);
+
+    let metaplexMetadataResult: MetaplexMetadataResult | undefined;
+
+    if (finalKind === "spl-token:mint" || finalKind === "spl-token-2022:mint") {
+      metaplexMetadataResult = await dependencies
+        .resolveMetaplexMetadata(identifier, cluster)
+        .catch((error): MetaplexMetadataResult => {
+          logger.warn({
+            event: "inspect_entity.safety_catch",
+            resolver: "metaplex_metadata",
+            identifier,
+            error,
+          });
+          return { status: "unknown", reason: "source_unavailable" };
+        });
+    }
+
+    const payload = buildAccountPayload({
+      kind: finalKind,
+      account: enrichedAccount,
+      ...(dasOutcome ? { dasOutcome } : {}),
+      ...(verificationResult ? { verificationResult } : {}),
+      ...(securityMetadataResult ? { securityMetadataResult } : {}),
+      ...(multisigReferenceResult ? { multisigReferenceResult } : {}),
+      ...(idlDiscoveryResult ? { idlDiscoveryResult } : {}),
+      ...(metaplexMetadataResult ? { metaplexMetadataResult } : {}),
+    });
+
+    return toToolResult({
+      payload,
+      errors: [],
+    });
+  } catch (error) {
+    logger.error({
+      event: "inspect_entity.resolve_account_failed",
+      identifier,
+      error,
+    });
+
+    if (isSourceUnavailableError(error)) {
+      return toToolResult({
+        payload: toSourceUnavailablePayload("account"),
+        errors: [internalError()],
+      });
+    }
+
+    return toToolResult({
+      payload: {},
+      errors: [internalError()],
+    });
+  }
+}
+
+// Transaction resolution — stub until Step 4 ports the real normalizer/builder.
+async function resolveTransaction(
+  _identifier: string,
+  _cluster: SupportedCluster,
+  _dependencies: InspectEntityDependencies,
+): Promise<CallToolResult> {
+  return toToolResult({
+    payload: {},
+    errors: [currentlyUnsupported("Transaction inspection is not yet available.")],
+  });
+}
+
+export async function handleInspectEntity(
+  rawInput: unknown,
+  dependencies: InspectEntityDependencies = defaultDependencies,
+): Promise<CallToolResult> {
+  const parseResult = inspectEntityInputSchema.safeParse(rawInput);
+  if (!parseResult.success) {
+    return toToolResult({
+      payload: {},
+      errors: [sanitizeToolError(parseResult.error)],
+    });
+  }
+
+  const input: InspectEntityArgs = parseResult.data;
+  const identifierKind = decodeIdentifierKind(input.identifier);
+
+  if (identifierKind === "invalid") {
+    return toToolResult({
+      payload: {},
+      errors: [invalidArgument("identifier must decode from base58 to 32 or 64 bytes")],
+    });
+  }
+
+  if (identifierKind === "account") {
+    return resolveAccount(input.identifier, input.cluster, dependencies);
+  }
+
+  return resolveTransaction(input.identifier, input.cluster, dependencies);
+}

--- a/lib/solana/metaplex-metadata.ts
+++ b/lib/solana/metaplex-metadata.ts
@@ -1,4 +1,10 @@
-import { fetchMetadata, findMetadataPda, mplTokenMetadata, type Metadata, TokenStandard } from "@metaplex-foundation/mpl-token-metadata";
+import {
+  fetchMetadata,
+  findMetadataPda,
+  mplTokenMetadata,
+  type Metadata,
+  TokenStandard,
+} from "@metaplex-foundation/mpl-token-metadata";
 import { publicKey, type Umi } from "@metaplex-foundation/umi";
 import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
 

--- a/lib/solana/metaplex-metadata.ts
+++ b/lib/solana/metaplex-metadata.ts
@@ -1,7 +1,6 @@
-import { fetchMetadata, findMetadataPda, type Metadata, TokenStandard } from "@metaplex-foundation/mpl-token-metadata";
+import { fetchMetadata, findMetadataPda, mplTokenMetadata, type Metadata, TokenStandard } from "@metaplex-foundation/mpl-token-metadata";
 import { publicKey, type Umi } from "@metaplex-foundation/umi";
 import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
-import { mplTokenMetadata } from "@metaplex-foundation/mpl-token-metadata";
 
 import { resolveRpcEndpoint } from "./rpc";
 import { METAPLEX_METADATA_TIMEOUT_MS, type SupportedCluster } from "./constants";

--- a/lib/solana/metaplex-metadata.ts
+++ b/lib/solana/metaplex-metadata.ts
@@ -1,0 +1,147 @@
+import { fetchMetadata, findMetadataPda, type Metadata, TokenStandard } from "@metaplex-foundation/mpl-token-metadata";
+import { publicKey, type Umi } from "@metaplex-foundation/umi";
+import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
+import { mplTokenMetadata } from "@metaplex-foundation/mpl-token-metadata";
+
+import { resolveRpcEndpoint } from "./rpc";
+import { METAPLEX_METADATA_TIMEOUT_MS, type SupportedCluster } from "./constants";
+import { raceWithTimeout } from "./timeout";
+import { logger } from "../observability/logger";
+
+const TOKEN_STANDARD_LABELS: Record<number, MetaplexTokenStandard> = {
+  [TokenStandard.NonFungible]: "NonFungible",
+  [TokenStandard.FungibleAsset]: "FungibleAsset",
+  [TokenStandard.Fungible]: "Fungible",
+  [TokenStandard.NonFungibleEdition]: "NonFungibleEdition",
+  [TokenStandard.ProgrammableNonFungible]: "ProgrammableNonFungible",
+  [TokenStandard.ProgrammableNonFungibleEdition]: "ProgrammableNonFungibleEdition",
+};
+
+export type MetaplexTokenStandard =
+  | "NonFungible"
+  | "FungibleAsset"
+  | "Fungible"
+  | "NonFungibleEdition"
+  | "ProgrammableNonFungible"
+  | "ProgrammableNonFungibleEdition";
+
+export type MetaplexCreator = {
+  address: string;
+  verified: boolean;
+  share: number;
+};
+
+export type MetaplexCollection = {
+  verified: boolean;
+  key: string;
+};
+
+export type MetaplexMetadataFound = {
+  status: "found";
+  name: string;
+  symbol: string;
+  uri: string;
+  seller_fee_basis_points: number;
+  creators: MetaplexCreator[] | null;
+  token_standard: MetaplexTokenStandard | null;
+  collection: MetaplexCollection | null;
+  is_collection: boolean;
+  primary_sale_happened: boolean;
+  is_mutable: boolean;
+};
+
+export type MetaplexMetadataResult =
+  | MetaplexMetadataFound
+  | { status: "not_found" }
+  | { status: "unknown"; reason: "source_unavailable" };
+
+// Per-endpoint UMI cache (same pattern as solana-explorer)
+const umiCache = new Map<string, Umi>();
+
+function getUmi(rpcEndpoint: string): Umi {
+  let umi = umiCache.get(rpcEndpoint);
+  if (!umi) {
+    umi = createUmi(rpcEndpoint).use(mplTokenMetadata());
+    umiCache.set(rpcEndpoint, umi);
+  }
+  return umi;
+}
+
+function isSome<T>(
+  option: { __option: "Some"; value: T } | { __option: "None" },
+): option is { __option: "Some"; value: T } {
+  return option.__option === "Some";
+}
+
+function normalizeMetadata(metadata: Metadata): MetaplexMetadataFound {
+  const tokenStandard = isSome(metadata.tokenStandard)
+    ? (TOKEN_STANDARD_LABELS[metadata.tokenStandard.value] ?? null)
+    : null;
+
+  const collection = isSome(metadata.collection)
+    ? { verified: metadata.collection.value.verified, key: metadata.collection.value.key.toString() }
+    : null;
+
+  const creators = isSome(metadata.creators)
+    ? metadata.creators.value.map(c => ({
+        address: c.address.toString(),
+        verified: c.verified,
+        share: c.share,
+      }))
+    : null;
+
+  const isCollection = isSome(metadata.collectionDetails);
+
+  return {
+    status: "found",
+    name: metadata.name.replace(/\0/g, "").trim(),
+    symbol: metadata.symbol.replace(/\0/g, "").trim(),
+    uri: metadata.uri.replace(/\0/g, "").trim(),
+    seller_fee_basis_points: metadata.sellerFeeBasisPoints,
+    creators,
+    token_standard: tokenStandard,
+    collection,
+    is_collection: isCollection,
+    primary_sale_happened: metadata.primarySaleHappened,
+    is_mutable: metadata.isMutable,
+  };
+}
+
+export async function resolveMetaplexMetadata(
+  mintAddress: string,
+  cluster: SupportedCluster,
+): Promise<MetaplexMetadataResult> {
+  const endpoint = resolveRpcEndpoint(cluster);
+  const umi = getUmi(endpoint);
+
+  try {
+    const mintKey = publicKey(mintAddress);
+    const metadataPda = findMetadataPda(umi, { mint: mintKey });
+
+    const metadata = await raceWithTimeout(
+      fetchMetadata(umi, metadataPda),
+      METAPLEX_METADATA_TIMEOUT_MS,
+      "Metaplex metadata fetch",
+    );
+
+    return normalizeMetadata(metadata);
+  } catch (error) {
+    // UMI throws when the account doesn't exist (e.g., fungible tokens without metadata)
+    const message = error instanceof Error ? error.message : String(error);
+    if (
+      message.includes("could not find account") ||
+      message.includes("Account does not exist") ||
+      message.includes("The account of type")
+    ) {
+      return { status: "not_found" };
+    }
+
+    logger.warn({
+      event: "metaplex_metadata.resolve_failed",
+      mintAddress,
+      cluster,
+      error,
+    });
+    return { status: "unknown", reason: "source_unavailable" };
+  }
+}

--- a/lib/solana/types.ts
+++ b/lib/solana/types.ts
@@ -1,3 +1,6 @@
+import type { MetaplexMetadataResult } from "./metaplex-metadata";
+export type { MetaplexMetadataResult };
+
 // Inlined from resolvers/security-txt-parser.ts (ported in Step 5)
 export type SecurityTxtFields = {
   name: string;
@@ -203,6 +206,7 @@ export type AccountPayloadContext = {
   securityMetadataResult?: SecurityMetadataResult;
   multisigReferenceResult?: MultisigReferenceResult;
   idlDiscoveryResult?: IdlDiscoveryResult;
+  metaplexMetadataResult?: MetaplexMetadataResult;
 };
 
 /** A numeric value that may be represented as a decimal string when it exceeds Number.MAX_SAFE_INTEGER. */

--- a/lib/tools/inspectEntityTools.ts
+++ b/lib/tools/inspectEntityTools.ts
@@ -1,0 +1,41 @@
+import type { SolanaTool } from "./types";
+import { handleInspectEntity, inspectEntityInputSchema } from "../solana/inspect-entity";
+
+const INSPECT_ENTITY_DESCRIPTION = [
+  "Retrieve detailed on-chain data for any Solana account or transaction.",
+  "Use this tool when a user asks about a Solana address, transaction, program, token, NFT, wallet, or other blockchain entity.",
+  "",
+  "IDENTIFIER: A base58-encoded string. Accepts account addresses (32-byte) and transaction signatures (64-byte) — the tool detects which type was provided.",
+  "",
+  "CLUSTER: Solana network to query (mainnet-beta, devnet, testnet, simd296). Defaults to mainnet-beta.",
+  "",
+  "ACCOUNT TYPES RETURNED (by entity.kind):",
+  '- "bpf-upgradeable-loader": Executable programs — address, label, balance, executable status, upgrade authority, last deployed slot, verification status, security metadata, IDL discovery, multisig details.',
+  '- "spl-token:mint" / "spl-token-2022:mint": Token mints — address, supply, decimals, mint/freeze authorities, supply type (fixed/variable), token program. Token-2022 mints also include parsed extensions.',
+  '- "spl-token:account" / "spl-token-2022:account": Token accounts — mint, owner, token program.',
+  '- "spl-token:multisig" / "spl-token-2022:multisig": Token multisigs — signers, threshold, initialization status.',
+  '- "compressed-nft": Compressed NFTs — asset ID, owner, merkle tree.',
+  '- "stake", "vote", "nonce", "sysvar", "config", "address-lookup-table", "feature", "nftoken", "solana-attestation-service": Recognized system account types.',
+  '- "unknown": Unrecognized account type.',
+  "",
+  "TRANSACTION DATA (entity.kind = transaction):",
+  'signature, slot, block time, status (success/failed/unknown), fee in lamports, ordered signer list, transaction version, recent blockhash, compute units consumed, confirmation status and confirmations (numeric count or "max" when finalized), error detail (when failed), program log messages, accounts with signer/writable roles, instructions with resolved program addresses and nested CPI (inner instructions). Numeric fields that exceed safe integer range are returned as decimal strings.',
+  "",
+  "OUTPUT: Responses use { payload: { entity: { kind, ...fields } }, errors: [] }. Unresolvable fields return explicit unknown markers instead of being silently omitted.",
+].join("\n");
+
+export const inspectEntityTools: SolanaTool[] = [
+  {
+    title: "inspect_entity",
+    description: INSPECT_ENTITY_DESCRIPTION,
+    parameters: inspectEntityInputSchema,
+    annotations: {
+      title: "Inspect Solana Entity",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    func: async input => handleInspectEntity(input),
+  },
+];

--- a/lib/tools/inspectEntityTools.ts
+++ b/lib/tools/inspectEntityTools.ts
@@ -18,8 +18,10 @@ const INSPECT_ENTITY_DESCRIPTION = [
   '- "stake", "vote", "nonce", "sysvar", "config", "address-lookup-table", "feature", "nftoken", "solana-attestation-service": Recognized system account types.',
   '- "unknown": Unrecognized account type.',
   "",
-  "TRANSACTION DATA (entity.kind = transaction):",
-  'signature, slot, block time, status (success/failed/unknown), fee in lamports, ordered signer list, transaction version, recent blockhash, compute units consumed, confirmation status and confirmations (numeric count or "max" when finalized), error detail (when failed), program log messages, accounts with signer/writable roles, instructions with resolved program addresses and nested CPI (inner instructions). Numeric fields that exceed safe integer range are returned as decimal strings.',
+  "NOTE: Transaction inspection is not yet supported and will be added in a future update. Currently only account addresses are resolved.",
+  // FIXME(@rogaldh): Replace with full TRANSACTION DATA description once resolveTransaction is implemented (Step 5):
+  // "TRANSACTION DATA (entity.kind = transaction):",
+  // 'signature, slot, block time, status (success/failed/unknown), fee in lamports, ordered signer list, transaction version, recent blockhash, compute units consumed, confirmation status and confirmations (numeric count or "max" when finalized), error detail (when failed), program log messages, accounts with signer/writable roles, instructions with resolved program addresses and nested CPI (inner instructions). Numeric fields that exceed safe integer range are returned as decimal strings.',
   "",
   "OUTPUT: Responses use { payload: { entity: { kind, ...fields } }, errors: [] }. Unresolvable fields return explicit unknown markers instead of being silently omitted.",
 ].join("\n");

--- a/lib/tools/types.ts
+++ b/lib/tools/types.ts
@@ -5,7 +5,13 @@ export type SolanaTool = {
   description?: string;
   parameters: z.ZodRawShape | z.ZodTypeAny;
   outputSchema?: z.ZodRawShape;
-  annotations?: Record<string, unknown>;
+  annotations?: {
+    title?: string;
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   func: (params: any) => Promise<any>;
 };

--- a/lib/tools/types.ts
+++ b/lib/tools/types.ts
@@ -3,8 +3,9 @@ import { z } from "zod";
 export type SolanaTool = {
   title: string;
   description?: string;
-  parameters: z.ZodRawShape;
+  parameters: z.ZodRawShape | z.ZodTypeAny;
   outputSchema?: z.ZodRawShape;
+  annotations?: Record<string, unknown>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   func: (params: any) => Promise<any>;
 };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "vercel dev",
+    "dev:local": "vercel dev --local",
     "test": "pnpm test:integration",
     "test:integration": "vitest run tests/integration.test.ts tests/unit/",
     "test:e2e": "vitest run tests/e2e.test.ts",
@@ -30,6 +31,9 @@
     "@ai-sdk/openai": "^3.0.52",
     "@duneanalytics/client-sdk": "^0.3.5",
     "@inkeep/inkeep-analytics": "0.2.4-alpha.36",
+    "@metaplex-foundation/mpl-token-metadata": "^3.4.0",
+    "@metaplex-foundation/umi": "^1.5.1",
+    "@metaplex-foundation/umi-bundle-defaults": "^1.5.1",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@neondatabase/serverless": "^1.0.2",
     "@noble/hashes": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,16 @@ importers:
         version: 0.3.5
       '@inkeep/inkeep-analytics':
         specifier: 0.2.4-alpha.36
-        version: 0.2.4-alpha.36(react@19.2.4)
+        version: 0.2.4-alpha.36(react-dom@19.2.5(react@19.2.4))(react@19.2.4)
+      '@metaplex-foundation/mpl-token-metadata':
+        specifier: ^3.4.0
+        version: 3.4.0(@metaplex-foundation/umi@1.5.1)
+      '@metaplex-foundation/umi':
+        specifier: ^1.5.1
+        version: 1.5.1
+      '@metaplex-foundation/umi-bundle-defaults':
+        specifier: ^1.5.1
+        version: 1.5.1(@metaplex-foundation/umi@1.5.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -67,7 +76,7 @@ importers:
         version: 2.16.11
       mcp-handler:
         specifier: 1.1.0
-        version: 1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
+        version: 1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(next@16.2.4(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.4))(react@19.2.4))
       raw-body:
         specifier: ^3.0.0
         version: 3.0.2
@@ -104,7 +113,7 @@ importers:
         version: 3.8.3
       tsup:
         specifier: ^8.5.0
-        version: 8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
@@ -116,7 +125,7 @@ importers:
         version: 51.2.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.3
-        version: 4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0))
+        version: 4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -735,6 +744,159 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@inkeep/inkeep-analytics@0.2.4-alpha.36':
     resolution: {integrity: sha512-L1Ei2rTUsvaKoXiGKbisl2ck6ZB5J3hlXM9GIwtlfgCMWUbqRn7Xs0xB4/6cyq7NrHQ4bMCTulmdw3PjqN/FHA==}
     hasBin: true
@@ -780,6 +942,92 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@metaplex-foundation/mpl-token-metadata@3.4.0':
+    resolution: {integrity: sha512-AxBAYCK73JWxY3g9//z/C9krkR0t1orXZDknUPS4+GjwGH2vgPfsk04yfZ31Htka2AdS9YE/3wH7sMUBHKn9Rg==}
+    peerDependencies:
+      '@metaplex-foundation/umi': '>= 0.8.2 <= 1'
+
+  '@metaplex-foundation/mpl-toolbox@0.10.0':
+    resolution: {integrity: sha512-84KD1L5cFyw5xnntHwL4uPwfcrkKSiwuDeypiVr92qCUFuF3ZENa2zlFVPu+pQcjTlod2LmEX3MhBmNjRMpdKg==}
+    peerDependencies:
+      '@metaplex-foundation/umi': '>= 0.8.2 <= 1'
+
+  '@metaplex-foundation/umi-bundle-defaults@1.5.1':
+    resolution: {integrity: sha512-7qoXenAkQbcj468HGAeLZDyg3eEhcS9rWAnGqjnKgWOlL1czL2Qwho0FEtqOv57IHwAJSTpbHbcvABmdpTjjdw==}
+    peerDependencies:
+      '@metaplex-foundation/umi': ^1.5.1
+      '@solana/web3.js': ^1.72.0
+
+  '@metaplex-foundation/umi-downloader-http@1.5.1':
+    resolution: {integrity: sha512-1s9gSTaDtwELyxBRE6Wmdr3xWeb4Z1uU04dj3Hg8VU+TN6/3wchh93+rIGZT5D3zzdh4+yPxdYV+4ZEr3T5glQ==}
+    peerDependencies:
+      '@metaplex-foundation/umi': ^1.5.1
+
+  '@metaplex-foundation/umi-eddsa-web3js@1.5.1':
+    resolution: {integrity: sha512-ZlzmXXAa1Ujk00G5TmqXM81J25+k/8sqt0zxBUlLTUSOxzlhxhlUKdErIhpHazbKq+eGck+Onm17oAwVKdKAcw==}
+    peerDependencies:
+      '@metaplex-foundation/umi': ^1.5.1
+      '@solana/web3.js': ^1.72.0
+
+  '@metaplex-foundation/umi-http-fetch@1.5.1':
+    resolution: {integrity: sha512-AOjZJo3Ua4a2FvgA85x5f0TkMSb+13Ao3uLIQ9FbScV42kqZnDox8KjJ7tKm1ZtYDlCYD0pSFMKPOC9NPDnHDg==}
+    peerDependencies:
+      '@metaplex-foundation/umi': ^1.5.1
+
+  '@metaplex-foundation/umi-options@1.5.1':
+    resolution: {integrity: sha512-ZE6uXgFA3rElFq4gJxZM2diAqZdFqL65bOnAggwdnnei5XXRzFyNF16wYSqlHnPLvG6ohRHWiXww8d2Mb83xFg==}
+
+  '@metaplex-foundation/umi-program-repository@1.5.1':
+    resolution: {integrity: sha512-E5W0IjwFgDGuBTshISbbEh/s8deqxcOzzEjOOlYdMXnevVsfNLwBBIAY4NPJg3v5vpFlKODwUGB5BxCUVthzJg==}
+    peerDependencies:
+      '@metaplex-foundation/umi': ^1.5.1
+
+  '@metaplex-foundation/umi-public-keys@1.5.1':
+    resolution: {integrity: sha512-joTnI1mRtYRfIaTo98uaYRjBPszsdyHuq0vvd6QbSX+MPvu3enkWi+UicuykEc3VXd5tcGdNMiGSx4jgXG6pkw==}
+
+  '@metaplex-foundation/umi-rpc-chunk-get-accounts@1.5.1':
+    resolution: {integrity: sha512-3dnGobT1Xwul7fXzQr8660UHSnFOCWEed4T449oNekrVsHp2o00fdOqjXwo11DYhS1rjm+gbzRSazRKb62uF2Q==}
+    peerDependencies:
+      '@metaplex-foundation/umi': ^1.5.1
+
+  '@metaplex-foundation/umi-rpc-web3js@1.5.1':
+    resolution: {integrity: sha512-CxHyruh2gW2b/ZOwHFFtooOgtu9hBrOJTd3HUMtD/jpaturApa3itsL/zNt4K34tELzVIUL7N78LDjNpzbu9Kw==}
+    peerDependencies:
+      '@metaplex-foundation/umi': ^1.5.1
+      '@solana/web3.js': ^1.72.0
+
+  '@metaplex-foundation/umi-serializer-data-view@1.5.1':
+    resolution: {integrity: sha512-9Wxqk3bGVJ0xNmHhHrOUhdu/90Q1IT3FZRZN4eGckb0sf7Bgls7kBTkFfgXFmUh2VBnE0GnnncXeHKtop5RSFA==}
+    peerDependencies:
+      '@metaplex-foundation/umi': ^1.5.1
+
+  '@metaplex-foundation/umi-serializers-core@1.5.1':
+    resolution: {integrity: sha512-6nYsbTCLq421x7JT1B3/iNgPpSARj/wL9naoKbOreHrk2ip/4R7vQstVRMl0Gx+Hv2tHnEIbFo3JBtWyC377Qw==}
+
+  '@metaplex-foundation/umi-serializers-encodings@1.5.1':
+    resolution: {integrity: sha512-cVvwWmREE/Pmvjvsd50F18P53HDT0vzZECD6uYWIVzxgwpOiRDFu6r/vGbweomHoWzfTvuU6hiKuKv2KsOoXQA==}
+
+  '@metaplex-foundation/umi-serializers-numbers@1.5.1':
+    resolution: {integrity: sha512-7DVF1VJIdT44Pe6qWKaqGu4YVgE10OeLMYpm7C16SujSBgQGB/I2bh8NBifyH2R3oHhoyfE9qgIKB3dgRazN6A==}
+
+  '@metaplex-foundation/umi-serializers@1.5.1':
+    resolution: {integrity: sha512-scXciBylbJ4iwfxOF1Xx2XiBzoYUD8fSKWTsMal5Rj1hMRDe6b2XZcsBOjio61iAr8aTtFPmKpqxeBdLwmQ0ZQ==}
+
+  '@metaplex-foundation/umi-transaction-factory-web3js@1.5.1':
+    resolution: {integrity: sha512-g4NfvtnmXtH1Q/Y9LdCsFtDRHQZmZWW7uKz+N9a+IVsJTTvpWFALMHm66dFDQGa0ExAYxAj7j6uZH2qDn0zarA==}
+    peerDependencies:
+      '@metaplex-foundation/umi': ^1.5.1
+      '@solana/web3.js': ^1.72.0
+
+  '@metaplex-foundation/umi-web3js-adapters@1.5.1':
+    resolution: {integrity: sha512-6W3JElD0B0EbgHofVKqk4PbP/JDrUHIKWciM7tEuXTDXbuXbSECDe7qlTU0JZXmVZNfYufI6FHnkCfPys2ZnIQ==}
+    peerDependencies:
+      '@metaplex-foundation/umi': ^1.5.1
+      '@solana/web3.js': ^1.72.0
+
+  '@metaplex-foundation/umi@1.5.1':
+    resolution: {integrity: sha512-ONRv5a0kv+23AMlR8oyFBHnjVg3o3N8pUfFcV4gzbg6OgZf87zHsPWBfED3OTJqx267v1bEn6d6DABXNFq9Z3A==}
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -799,6 +1047,61 @@ packages:
   '@neondatabase/serverless@1.0.2':
     resolution: {integrity: sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==}
     engines: {node: '>=19.0.0'}
+
+  '@next/env@16.2.4':
+    resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
+
+  '@next/swc-darwin-arm64@16.2.4':
+    resolution: {integrity: sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@16.2.4':
+    resolution: {integrity: sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@16.2.4':
+    resolution: {integrity: sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@16.2.4':
+    resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@16.2.4':
+    resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@16.2.4':
+    resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@16.2.4':
+    resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.2.4':
+    resolution: {integrity: sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
 
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
@@ -1841,6 +2144,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
   '@swc/helpers@0.5.20':
     resolution: {integrity: sha512-2egEBHUMasdypIzrprsu8g+OEVd7Vp2MM3a2eVlM/cyFYto0nGz5BX5BTgh/ShZZI9ed+ozEq+Ngt+rgmUs8tw==}
 
@@ -2233,6 +2539,11 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  baseline-browser-mapping@2.10.20:
+    resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   basic-ftp@5.2.2:
     resolution: {integrity: sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==}
     engines: {node: '>=10.0.0'}
@@ -2303,6 +2614,9 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  caniuse-lite@1.0.30001788:
+    resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -2325,6 +2639,9 @@ packages:
 
   cjs-module-lexer@1.2.3:
     resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
@@ -3154,6 +3471,27 @@ packages:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
     engines: {node: '>= 0.4.0'}
 
+  next@16.2.4:
+    resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -3350,6 +3688,10 @@ packages:
       yaml:
         optional: true
 
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.9:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3427,6 +3769,11 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -3500,6 +3847,9 @@ packages:
     resolution: {integrity: sha512-tnFr7nyiuEhsAGb+xy60SDbij0790X+FgDljh3J/2HaRM6yQgNJkQKHbDH8ld7mR+PozXGgEfJ2Dc/5OyFnwsg==}
     hasBin: true
 
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -3527,6 +3877,10 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3630,6 +3984,19 @@ packages:
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -3995,6 +4362,11 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yauzl-clone@1.0.4:
     resolution: {integrity: sha512-igM2RRCf3k8TvZoxR2oguuw4z1xasOnA31joCqHIyLkeWrvAc2Jgay5ISQ2ZplinkoGaJ6orCz56Ey456c5ESA==}
@@ -4387,12 +4759,110 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inkeep/inkeep-analytics@0.2.4-alpha.36(react@19.2.4)':
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.9.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@inkeep/inkeep-analytics@0.2.4-alpha.36(react-dom@19.2.5(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
       react: 19.2.4
+      react-dom: 19.2.5(react@19.2.4)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
@@ -4434,6 +4904,109 @@ snapshots:
       - encoding
       - supports-color
 
+  '@metaplex-foundation/mpl-token-metadata@3.4.0(@metaplex-foundation/umi@1.5.1)':
+    dependencies:
+      '@metaplex-foundation/mpl-toolbox': 0.10.0(@metaplex-foundation/umi@1.5.1)
+      '@metaplex-foundation/umi': 1.5.1
+
+  '@metaplex-foundation/mpl-toolbox@0.10.0(@metaplex-foundation/umi@1.5.1)':
+    dependencies:
+      '@metaplex-foundation/umi': 1.5.1
+
+  '@metaplex-foundation/umi-bundle-defaults@1.5.1(@metaplex-foundation/umi@1.5.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@metaplex-foundation/umi': 1.5.1
+      '@metaplex-foundation/umi-downloader-http': 1.5.1(@metaplex-foundation/umi@1.5.1)
+      '@metaplex-foundation/umi-eddsa-web3js': 1.5.1(@metaplex-foundation/umi@1.5.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@metaplex-foundation/umi-http-fetch': 1.5.1(@metaplex-foundation/umi@1.5.1)
+      '@metaplex-foundation/umi-program-repository': 1.5.1(@metaplex-foundation/umi@1.5.1)
+      '@metaplex-foundation/umi-rpc-chunk-get-accounts': 1.5.1(@metaplex-foundation/umi@1.5.1)
+      '@metaplex-foundation/umi-rpc-web3js': 1.5.1(@metaplex-foundation/umi@1.5.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@metaplex-foundation/umi-serializer-data-view': 1.5.1(@metaplex-foundation/umi@1.5.1)
+      '@metaplex-foundation/umi-transaction-factory-web3js': 1.5.1(@metaplex-foundation/umi@1.5.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - encoding
+
+  '@metaplex-foundation/umi-downloader-http@1.5.1(@metaplex-foundation/umi@1.5.1)':
+    dependencies:
+      '@metaplex-foundation/umi': 1.5.1
+
+  '@metaplex-foundation/umi-eddsa-web3js@1.5.1(@metaplex-foundation/umi@1.5.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@metaplex-foundation/umi': 1.5.1
+      '@metaplex-foundation/umi-web3js-adapters': 1.5.1(@metaplex-foundation/umi@1.5.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@noble/curves': 1.9.7
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      yaml: 2.8.3
+
+  '@metaplex-foundation/umi-http-fetch@1.5.1(@metaplex-foundation/umi@1.5.1)':
+    dependencies:
+      '@metaplex-foundation/umi': 1.5.1
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@metaplex-foundation/umi-options@1.5.1': {}
+
+  '@metaplex-foundation/umi-program-repository@1.5.1(@metaplex-foundation/umi@1.5.1)':
+    dependencies:
+      '@metaplex-foundation/umi': 1.5.1
+
+  '@metaplex-foundation/umi-public-keys@1.5.1':
+    dependencies:
+      '@metaplex-foundation/umi-serializers-encodings': 1.5.1
+
+  '@metaplex-foundation/umi-rpc-chunk-get-accounts@1.5.1(@metaplex-foundation/umi@1.5.1)':
+    dependencies:
+      '@metaplex-foundation/umi': 1.5.1
+
+  '@metaplex-foundation/umi-rpc-web3js@1.5.1(@metaplex-foundation/umi@1.5.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@metaplex-foundation/umi': 1.5.1
+      '@metaplex-foundation/umi-web3js-adapters': 1.5.1(@metaplex-foundation/umi@1.5.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+
+  '@metaplex-foundation/umi-serializer-data-view@1.5.1(@metaplex-foundation/umi@1.5.1)':
+    dependencies:
+      '@metaplex-foundation/umi': 1.5.1
+
+  '@metaplex-foundation/umi-serializers-core@1.5.1': {}
+
+  '@metaplex-foundation/umi-serializers-encodings@1.5.1':
+    dependencies:
+      '@metaplex-foundation/umi-serializers-core': 1.5.1
+
+  '@metaplex-foundation/umi-serializers-numbers@1.5.1':
+    dependencies:
+      '@metaplex-foundation/umi-serializers-core': 1.5.1
+
+  '@metaplex-foundation/umi-serializers@1.5.1':
+    dependencies:
+      '@metaplex-foundation/umi-options': 1.5.1
+      '@metaplex-foundation/umi-public-keys': 1.5.1
+      '@metaplex-foundation/umi-serializers-core': 1.5.1
+      '@metaplex-foundation/umi-serializers-encodings': 1.5.1
+      '@metaplex-foundation/umi-serializers-numbers': 1.5.1
+
+  '@metaplex-foundation/umi-transaction-factory-web3js@1.5.1(@metaplex-foundation/umi@1.5.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@metaplex-foundation/umi': 1.5.1
+      '@metaplex-foundation/umi-web3js-adapters': 1.5.1(@metaplex-foundation/umi@1.5.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+
+  '@metaplex-foundation/umi-web3js-adapters@1.5.1(@metaplex-foundation/umi@1.5.1)(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@metaplex-foundation/umi': 1.5.1
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      buffer: 6.0.3
+
+  '@metaplex-foundation/umi@1.5.1':
+    dependencies:
+      '@metaplex-foundation/umi-options': 1.5.1
+      '@metaplex-foundation/umi-public-keys': 1.5.1
+      '@metaplex-foundation/umi-serializers': 1.5.1
+
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.12)
@@ -4467,6 +5040,33 @@ snapshots:
     dependencies:
       '@types/node': 22.19.17
       '@types/pg': 8.20.0
+
+  '@next/env@16.2.4':
+    optional: true
+
+  '@next/swc-darwin-arm64@16.2.4':
+    optional: true
+
+  '@next/swc-darwin-x64@16.2.4':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.2.4':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.2.4':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.2.4':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.2.4':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@16.2.4':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.2.4':
+    optional: true
 
   '@noble/curves@1.9.7':
     dependencies:
@@ -5351,6 +5951,11 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@swc/helpers@0.5.20':
     dependencies:
       tslib: 2.8.1
@@ -5826,7 +6431,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0))
+      vitest: 4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -5837,13 +6442,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.4(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.6.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -5973,6 +6578,9 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  baseline-browser-mapping@2.10.20:
+    optional: true
+
   basic-ftp@5.2.2: {}
 
   bindings@1.5.0:
@@ -6055,6 +6663,9 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  caniuse-lite@1.0.30001788:
+    optional: true
+
   chai@6.2.2: {}
 
   chalk@5.6.2: {}
@@ -6070,6 +6681,9 @@ snapshots:
   chownr@3.0.0: {}
 
   cjs-module-lexer@1.2.3: {}
+
+  client-only@0.0.1:
+    optional: true
 
   cluster-key-slot@1.1.2: {}
 
@@ -6853,12 +7467,14 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)):
+  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(next@16.2.4(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.4))(react@19.2.4)):
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       chalk: 5.6.2
       commander: 11.1.0
       redis: 4.7.1
+    optionalDependencies:
+      next: 16.2.4(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.4))(react@19.2.4)
 
   media-typer@1.1.0: {}
 
@@ -6941,6 +7557,32 @@ snapshots:
   negotiator@1.0.0: {}
 
   netmask@2.1.1: {}
+
+  next@16.2.4(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@next/env': 16.2.4
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.20
+      caniuse-lite: 1.0.30001788
+      postcss: 8.4.31
+      react: 19.2.4
+      react-dom: 19.2.5(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.4
+      '@next/swc-darwin-x64': 16.2.4
+      '@next/swc-linux-arm64-gnu': 16.2.4
+      '@next/swc-linux-arm64-musl': 16.2.4
+      '@next/swc-linux-x64-gnu': 16.2.4
+      '@next/swc-linux-x64-musl': 16.2.4
+      '@next/swc-win32-arm64-msvc': 16.2.4
+      '@next/swc-win32-x64-msvc': 16.2.4
+      '@opentelemetry/api': 1.9.0
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    optional: true
 
   node-fetch@2.6.7:
     dependencies:
@@ -7110,12 +7752,20 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.9)(tsx@4.21.0):
+  postcss-load-config@6.0.1(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.9
       tsx: 4.21.0
+      yaml: 2.8.3
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+    optional: true
 
   postcss@8.5.9:
     dependencies:
@@ -7195,6 +7845,12 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  react-dom@19.2.5(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+    optional: true
 
   react@19.2.4:
     optional: true
@@ -7358,6 +8014,9 @@ snapshots:
       - react-native-b4a
       - supports-color
 
+  scheduler@0.27.0:
+    optional: true
+
   semver@6.3.1: {}
 
   semver@7.5.4:
@@ -7394,6 +8053,38 @@ snapshots:
   setprototypeof@1.1.1: {}
 
   setprototypeof@1.2.0: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -7499,6 +8190,12 @@ snapshots:
       - react-native-b4a
 
   strip-final-newline@2.0.0: {}
+
+  styled-jsx@5.1.6(react@19.2.4):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.4
+    optional: true
 
   sucrase@3.35.1:
     dependencies:
@@ -7612,7 +8309,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14
@@ -7623,7 +8320,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.9)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.0
       source-map: 0.7.6
@@ -7752,7 +8449,7 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0):
+  vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -7764,11 +8461,12 @@ snapshots:
       '@types/node': 25.6.0
       fsevents: 2.3.3
       tsx: 4.21.0
+      yaml: 2.8.3
 
-  vitest@4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)):
+  vitest@4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.4(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -7785,7 +8483,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.6.0)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 3.2.0
@@ -7840,6 +8538,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml@2.8.3: {}
 
   yauzl-clone@1.0.4:
     dependencies:

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { resources } from "../lib/resources";
 import { solanaEcosystemTools } from "../lib/tools/ecosystemSolanaTools";
+import { inspectEntityTools } from "../lib/tools/inspectEntityTools";
 import * as generalSolanaToolsModule from "../lib/tools/generalSolanaTools";
 import type { SolanaTool } from "../lib/tools/types";
 
@@ -50,7 +51,11 @@ function resolveGeneralSolanaTools(): SolanaTool[] {
   return [];
 }
 
-const allTools: SolanaTool[] = ([] as SolanaTool[]).concat(resolveGeneralSolanaTools(), solanaEcosystemTools);
+const allTools: SolanaTool[] = ([] as SolanaTool[]).concat(
+  resolveGeneralSolanaTools(),
+  solanaEcosystemTools,
+  inspectEntityTools,
+);
 
 describe("createMcp", () => {
   beforeEach(() => {
@@ -116,11 +121,11 @@ describe("createMcp", () => {
 
     await initializeServer(server);
 
-    const toolsWithOutputSchema = allTools.filter(tool => tool.outputSchema !== undefined);
-    const toolsWithoutOutputSchema = allTools.filter(tool => tool.outputSchema === undefined);
+    const toolsViaRegisterTool = allTools.filter(t => t.outputSchema !== undefined || t.annotations !== undefined);
+    const toolsViaTool = allTools.filter(t => t.outputSchema === undefined && t.annotations === undefined);
 
-    expect(registerToolMock).toHaveBeenCalledTimes(toolsWithOutputSchema.length);
-    expect(toolMock).toHaveBeenCalledTimes(toolsWithoutOutputSchema.length);
+    expect(registerToolMock).toHaveBeenCalledTimes(toolsViaRegisterTool.length);
+    expect(toolMock).toHaveBeenCalledTimes(toolsViaTool.length);
 
     const registerToolCalls = registerToolMock.mock.calls as Array<
       [
@@ -129,12 +134,12 @@ describe("createMcp", () => {
           description: string;
           inputSchema: unknown;
           outputSchema: unknown;
-          annotations: Record<string, never>;
+          annotations: Record<string, unknown>;
         },
         unknown,
       ]
     >;
-    for (const tool of toolsWithOutputSchema) {
+    for (const tool of toolsViaRegisterTool) {
       const matchingCall = registerToolCalls.find(([name]) => name === tool.title);
       expect(matchingCall).toBeDefined();
       if (!matchingCall) {
@@ -144,13 +149,15 @@ describe("createMcp", () => {
       const [, options, handler] = matchingCall;
       expect(options.description).toBe(tool.description ?? "");
       expect(options.inputSchema).toBeDefined();
-      expect(options.outputSchema).toBeDefined();
-      expect(options.annotations).toEqual({});
+      if (tool.outputSchema) {
+        expect(options.outputSchema).toBeDefined();
+      }
+      expect(options.annotations).toEqual(tool.annotations ?? {});
       expect(typeof handler).toBe("function");
     }
 
     const toolCalls = toolMock.mock.calls as Array<[string, string, unknown, unknown]>;
-    for (const tool of toolsWithoutOutputSchema) {
+    for (const tool of toolsViaTool) {
       const matchingCall = toolCalls.find(([name]) => name === tool.title);
       expect(matchingCall).toBeDefined();
       if (!matchingCall) {

--- a/tests/unit/solana/inspect-entity-account-router.test.ts
+++ b/tests/unit/solana/inspect-entity-account-router.test.ts
@@ -219,7 +219,7 @@ describe("inspect-entity account router", () => {
     });
   });
 
-  it("builds spl-token:mint payload with core mint fields", () => {
+  it("builds spl-token:mint payload with core mint fields and null metaplex_metadata", () => {
     const payload = buildAccountPayloadWithRouter(contextForKind("spl-token:mint"));
     expect(payload).toMatchObject({
       entity: {
@@ -232,9 +232,38 @@ describe("inspect-entity account router", () => {
         mint_authority: "AuthAddr1111111111111111111111111111111111111",
         freeze_authority: null,
         supply_type: "variable",
+        metaplex_metadata: null,
       },
     });
     expect(payload.entity).not.toHaveProperty("extensions");
+  });
+
+  it("builds spl-token:mint payload with metaplex_metadata when present", () => {
+    const context = contextForKind("spl-token:mint");
+    context.metaplexMetadataResult = {
+      status: "found",
+      name: "Test NFT",
+      symbol: "TNFT",
+      uri: "https://example.com/nft.json",
+      seller_fee_basis_points: 250,
+      creators: [{ address: "Creator111", verified: true, share: 100 }],
+      token_standard: "ProgrammableNonFungible",
+      collection: { verified: true, key: "Collection111" },
+      is_collection: false,
+      primary_sale_happened: false,
+      is_mutable: true,
+    };
+    const payload = buildAccountPayloadWithRouter(context);
+    expect(payload).toMatchObject({
+      entity: {
+        kind: "spl-token:mint",
+        metaplex_metadata: {
+          name: "Test NFT",
+          token_standard: "ProgrammableNonFungible",
+          collection: { verified: true, key: "Collection111" },
+        },
+      },
+    });
   });
 
   it("builds spl-token-2022:mint payload with extensions", () => {

--- a/tests/unit/solana/inspect-entity.test.ts
+++ b/tests/unit/solana/inspect-entity.test.ts
@@ -1,0 +1,409 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it, vi } from "vitest";
+
+import { SourceUnavailableError } from "../../../lib/solana/rpc";
+import { handleInspectEntity } from "../../../lib/solana/inspect-entity";
+
+const ACCOUNT_IDENTIFIER = "11111111111111111111111111111111";
+const TRANSACTION_IDENTIFIER =
+  "4ReKprwf3WdLHRrzp4ctPWNBsQDPL3VZz3zMmoZfcGJMJCHh5Vq937mPdyxhCbw54wNnA6hZ7KfNpQdpt13yY7A9";
+
+type InspectEntityDeps = Parameters<typeof handleInspectEntity>[1];
+
+function createDependencies(overrides: Partial<InspectEntityDeps> = {}): InspectEntityDeps {
+  return {
+    fetchAccountInfo: vi.fn().mockResolvedValue({ value: null }),
+    fetchTransaction: vi.fn().mockResolvedValue(null),
+    fetchAsset: vi.fn().mockResolvedValue(null),
+    resolveProgramVerification: vi.fn().mockResolvedValue({ status: "unknown", reason: "source_unavailable" }),
+    resolveProgramSecurityMetadata: vi.fn().mockResolvedValue({ status: "unknown", reason: "source_unavailable" }),
+    resolveMultisigReference: vi.fn().mockResolvedValue({ status: "not_multisig" }),
+    resolveProgramIdl: vi.fn().mockResolvedValue({ status: "not_found" }),
+    resolveMetaplexMetadata: vi.fn().mockResolvedValue({ status: "not_found" }),
+    fetchSignatureStatus: vi.fn().mockResolvedValue({ value: null }),
+    ...overrides,
+  };
+}
+
+function parseEnvelope(result: CallToolResult): Record<string, unknown> {
+  const contentItem = result.content[0];
+  if (!contentItem || contentItem.type !== "text") {
+    throw new Error("Expected text content envelope.");
+  }
+  const parsed = JSON.parse(contentItem.text) as Record<string, unknown>;
+  expect(parsed).toEqual(result.structuredContent);
+  return parsed;
+}
+
+describe("inspect_entity handler", () => {
+  it("returns INVALID_ARGUMENT for malformed or oversized input", async () => {
+    const resultMalformed = await handleInspectEntity({});
+    const malformedEnvelope = parseEnvelope(resultMalformed);
+
+    expect(resultMalformed.isError).toBe(true);
+    expect(malformedEnvelope).toMatchObject({
+      errors: [{ code: "INVALID_ARGUMENT", message: expect.stringContaining("identifier") }],
+    });
+
+    const resultOversized = await handleInspectEntity({ identifier: "1".repeat(129) });
+    const oversizedEnvelope = parseEnvelope(resultOversized);
+    expect(oversizedEnvelope).toMatchObject({
+      errors: [{ code: "INVALID_ARGUMENT" }],
+    });
+  });
+
+  it("rejects identifiers that do not decode to 32 or 64 bytes", async () => {
+    const result = await handleInspectEntity({ identifier: "abc" });
+    const envelope = parseEnvelope(result);
+
+    expect(envelope).toMatchObject({
+      errors: [{ code: "INVALID_ARGUMENT", message: "identifier must decode from base58 to 32 or 64 bytes" }],
+    });
+  });
+
+  it("returns NOT_FOUND for account probes with explicit null", async () => {
+    const dependencies = createDependencies({
+      fetchAccountInfo: vi.fn().mockResolvedValue({ value: null }),
+    });
+
+    const result = await handleInspectEntity({ identifier: ACCOUNT_IDENTIFIER }, dependencies);
+    const envelope = parseEnvelope(result);
+
+    expect(envelope).toMatchObject({
+      payload: { entity: { kind: "account" } },
+      errors: [{ code: "NOT_FOUND" }],
+    });
+  });
+
+  it("maps account timeout failures to INTERNAL_ERROR with fixed source marker", async () => {
+    const dependencies = createDependencies({
+      fetchAccountInfo: vi.fn().mockRejectedValue(new SourceUnavailableError("RPC request timed out.")),
+    });
+
+    const result = await handleInspectEntity({ identifier: ACCOUNT_IDENTIFIER }, dependencies);
+    const envelope = parseEnvelope(result);
+
+    expect(envelope).toMatchObject({
+      payload: {
+        entity: {
+          kind: "account",
+          source: { value: null, status: "unknown", reason: "source_unavailable" },
+        },
+      },
+      errors: [{ code: "INTERNAL_ERROR" }],
+    });
+  });
+
+  it("maps generic fetchAccountInfo errors to INTERNAL_ERROR without source marker", async () => {
+    const dependencies = createDependencies({
+      fetchAccountInfo: vi.fn().mockRejectedValue(new Error("unexpected")),
+    });
+
+    const result = await handleInspectEntity({ identifier: ACCOUNT_IDENTIFIER }, dependencies);
+    const envelope = parseEnvelope(result);
+
+    expect(result.isError).toBe(true);
+    expect(envelope).toMatchObject({
+      payload: {},
+      errors: [{ code: "INTERNAL_ERROR" }],
+    });
+  });
+
+  it("skips DAS lookup when base account kind is already known", async () => {
+    const fetchAsset = vi.fn();
+    const dependencies = createDependencies({
+      fetchAccountInfo: vi.fn().mockResolvedValue({
+        value: {
+          owner: "Stake11111111111111111111111111111111111111",
+          lamports: 0,
+          executable: false,
+          data: { program: "stake", parsed: {} },
+        },
+      }),
+      fetchAsset,
+    });
+
+    const result = await handleInspectEntity({ identifier: ACCOUNT_IDENTIFIER }, dependencies);
+
+    expect(result.isError).toBe(false);
+    expect(fetchAsset).not.toHaveBeenCalled();
+  });
+
+  it("issues a second RPC probe for upgradeable programData", async () => {
+    const executableDataAddress = "DoU57AYuPfu2QU514RktNPG220AhpEjnKxnBcu4HDTY";
+    const fetchAccountInfo = vi
+      .fn()
+      .mockResolvedValueOnce({
+        value: {
+          owner: "BPFLoaderUpgradeab1e11111111111111111111111",
+          lamports: 567591537,
+          executable: true,
+          data: {
+            program: "bpf-upgradeable-loader",
+            parsed: { type: "program", info: { programData: executableDataAddress } },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        value: {
+          owner: "BPFLoaderUpgradeab1e11111111111111111111111",
+          lamports: 0,
+          executable: false,
+          data: {
+            program: "bpf-upgradeable-loader",
+            parsed: {
+              type: "programData",
+              info: {
+                authority: "AeLnXCBPaQHGWRLr2saFsEVfnMNuKixRAbWCT9P5twgZ",
+                data: [Buffer.from("00", "hex").toString("base64"), "base64"],
+                slot: 395847597,
+              },
+            },
+          },
+        },
+      });
+    const dependencies = createDependencies({ fetchAccountInfo });
+
+    const result = await handleInspectEntity({ identifier: ACCOUNT_IDENTIFIER }, dependencies);
+    const envelope = parseEnvelope(result);
+
+    expect(result.isError).toBe(false);
+    expect(fetchAccountInfo).toHaveBeenCalledTimes(2);
+    expect(envelope).toMatchObject({
+      payload: { entity: { kind: "bpf-upgradeable-loader" } },
+      errors: [],
+    });
+  });
+
+  it("stays successful when second programData probe is unavailable", async () => {
+    const fetchAccountInfo = vi
+      .fn()
+      .mockResolvedValueOnce({
+        value: {
+          owner: "BPFLoaderUpgradeab1e11111111111111111111111",
+          lamports: 567591537,
+          executable: true,
+          data: {
+            program: "bpf-upgradeable-loader",
+            parsed: { type: "program", info: { programData: "DoU57AYuPfu2QU514RktNPG220AhpEjnKxnBcu4HDTY" } },
+          },
+        },
+      })
+      .mockRejectedValueOnce(new SourceUnavailableError("probe timeout"));
+    const dependencies = createDependencies({ fetchAccountInfo });
+
+    const result = await handleInspectEntity({ identifier: ACCOUNT_IDENTIFIER }, dependencies);
+
+    expect(result.isError).toBe(false);
+    const envelope = parseEnvelope(result);
+    expect(envelope).toMatchObject({
+      payload: { entity: { kind: "bpf-upgradeable-loader" } },
+      errors: [],
+    });
+  });
+
+  it("treats malformed second programData payload as non-error", async () => {
+    const fetchAccountInfo = vi
+      .fn()
+      .mockResolvedValueOnce({
+        value: {
+          owner: "BPFLoaderUpgradeab1e11111111111111111111111",
+          lamports: 567591537,
+          executable: true,
+          data: {
+            program: "bpf-upgradeable-loader",
+            parsed: { type: "program", info: { programData: "DoU57AYuPfu2QU514RktNPG220AhpEjnKxnBcu4HDTY" } },
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        value: {
+          owner: "BPFLoaderUpgradeab1e11111111111111111111111",
+          lamports: 0,
+          executable: false,
+          data: { program: "other", parsed: null },
+        },
+      });
+    const dependencies = createDependencies({ fetchAccountInfo });
+
+    const result = await handleInspectEntity({ identifier: ACCOUNT_IDENTIFIER }, dependencies);
+
+    expect(result.isError).toBe(false);
+    const envelope = parseEnvelope(result);
+    expect(envelope).toMatchObject({
+      payload: { entity: { kind: "bpf-upgradeable-loader" } },
+      errors: [],
+    });
+  });
+
+  it("promotes unknown account to compressed-nft via DAS", async () => {
+    const fetchAsset = vi.fn().mockResolvedValue({
+      id: "asset-id",
+      compression: { compressed: true, tree: "tree-id" },
+      ownership: { owner: "owner-id" },
+    });
+    const dependencies = createDependencies({
+      fetchAccountInfo: vi.fn().mockResolvedValue({
+        value: {
+          owner: "UnknownOwner",
+          lamports: 0,
+          executable: false,
+          data: { program: "unknown-program", parsed: { type: "other" } },
+        },
+      }),
+      fetchAsset,
+    });
+
+    const result = await handleInspectEntity({ identifier: ACCOUNT_IDENTIFIER }, dependencies);
+    const envelope = parseEnvelope(result);
+
+    expect(result.isError).toBe(false);
+    expect(fetchAsset).toHaveBeenCalledTimes(1);
+    expect(envelope).toMatchObject({
+      payload: { entity: { kind: "compressed-nft" } },
+      errors: [],
+    });
+  });
+
+  it("falls back to unknown kind when DAS lookup fails", async () => {
+    const dependencies = createDependencies({
+      fetchAccountInfo: vi.fn().mockResolvedValue({
+        value: {
+          owner: "UnknownOwner",
+          lamports: 0,
+          executable: false,
+          data: { program: "unknown-program", parsed: { type: "other" } },
+        },
+      }),
+      fetchAsset: vi.fn().mockRejectedValue(new Error("das unavailable")),
+    });
+
+    const result = await handleInspectEntity({ identifier: ACCOUNT_IDENTIFIER }, dependencies);
+    const envelope = parseEnvelope(result);
+
+    expect(result.isError).toBe(false);
+    expect(envelope).toMatchObject({
+      payload: { entity: { kind: "unknown" } },
+      errors: [],
+    });
+  });
+
+  it("classifies ALT from raw bytes without DAS lookup", async () => {
+    const fetchAsset = vi.fn();
+    const dependencies = createDependencies({
+      fetchAccountInfo: vi.fn().mockResolvedValue({
+        value: {
+          owner: "AddressLookupTab1e1111111111111111111111111",
+          lamports: 0,
+          executable: false,
+          data: [Buffer.from(new Uint8Array(56)).toString("base64"), "base64"],
+        },
+      }),
+      fetchAsset,
+    });
+
+    const result = await handleInspectEntity({ identifier: ACCOUNT_IDENTIFIER }, dependencies);
+
+    expect(result.isError).toBe(false);
+    expect(fetchAsset).not.toHaveBeenCalled();
+  });
+
+  it("resolves Metaplex metadata for spl-token:mint accounts", async () => {
+    const resolveMetaplexMetadata = vi.fn().mockResolvedValue({
+      status: "found",
+      name: "My NFT",
+      symbol: "MNFT",
+      uri: "https://example.com/nft.json",
+      seller_fee_basis_points: 500,
+      creators: [{ address: "Creator111", verified: true, share: 100 }],
+      token_standard: "NonFungible",
+      collection: { verified: true, key: "Collection111" },
+      is_collection: false,
+      primary_sale_happened: true,
+      is_mutable: true,
+    });
+    const dependencies = createDependencies({
+      fetchAccountInfo: vi.fn().mockResolvedValue({
+        value: {
+          owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+          lamports: 0,
+          executable: false,
+          data: {
+            program: "spl-token",
+            parsed: {
+              type: "mint",
+              info: {
+                supply: "1",
+                decimals: 0,
+                isInitialized: true,
+                mintAuthority: null,
+                freezeAuthority: null,
+              },
+            },
+          },
+        },
+      }),
+      resolveMetaplexMetadata,
+    });
+
+    const result = await handleInspectEntity({ identifier: ACCOUNT_IDENTIFIER }, dependencies);
+    const envelope = parseEnvelope(result);
+
+    expect(result.isError).toBe(false);
+    expect(resolveMetaplexMetadata).toHaveBeenCalledWith(ACCOUNT_IDENTIFIER, "mainnet-beta");
+    expect(envelope).toMatchObject({
+      payload: {
+        entity: {
+          kind: "spl-token:mint",
+          metaplex_metadata: {
+            name: "My NFT",
+            token_standard: "NonFungible",
+          },
+        },
+      },
+    });
+  });
+
+  it("skips Metaplex metadata for non-mint account kinds", async () => {
+    const resolveMetaplexMetadata = vi.fn();
+    const dependencies = createDependencies({
+      fetchAccountInfo: vi.fn().mockResolvedValue({
+        value: {
+          owner: "Stake11111111111111111111111111111111111111",
+          lamports: 0,
+          executable: false,
+          data: { program: "stake", parsed: {} },
+        },
+      }),
+      resolveMetaplexMetadata,
+    });
+
+    await handleInspectEntity({ identifier: ACCOUNT_IDENTIFIER }, dependencies);
+
+    expect(resolveMetaplexMetadata).not.toHaveBeenCalled();
+  });
+
+  it("returns CURRENTLY_UNSUPPORTED for transaction identifiers", async () => {
+    const result = await handleInspectEntity({ identifier: TRANSACTION_IDENTIFIER });
+    const envelope = parseEnvelope(result);
+
+    expect(result.isError).toBe(true);
+    expect(envelope).toMatchObject({
+      errors: [{ code: "CURRENTLY_UNSUPPORTED" }],
+    });
+  });
+
+  it("returns INTERNAL_ERROR when account probe payload is malformed", async () => {
+    const dependencies = createDependencies({
+      fetchAccountInfo: vi.fn().mockResolvedValue({ value: undefined }),
+    });
+
+    const result = await handleInspectEntity({ identifier: ACCOUNT_IDENTIFIER }, dependencies);
+    const envelope = parseEnvelope(result);
+
+    expect(envelope).toMatchObject({
+      payload: {},
+      errors: [{ code: "INTERNAL_ERROR" }],
+    });
+  });
+});

--- a/tests/unit/solana/metaplex-metadata.test.ts
+++ b/tests/unit/solana/metaplex-metadata.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { buildMetaplexMetadataField } from "../../../lib/solana/account-kinds/shared";
+import type { MetaplexMetadataResult } from "../../../lib/solana/types";
+
+describe("buildMetaplexMetadataField", () => {
+  it("returns null when result is undefined", () => {
+    expect(buildMetaplexMetadataField(undefined)).toBeNull();
+  });
+
+  it("returns null when result is not_found", () => {
+    expect(buildMetaplexMetadataField({ status: "not_found" })).toBeNull();
+  });
+
+  it("returns unknown marker when result is source_unavailable", () => {
+    expect(buildMetaplexMetadataField({ status: "unknown", reason: "source_unavailable" })).toEqual({
+      value: null,
+      status: "unknown",
+      reason: "source_unavailable",
+    });
+  });
+
+  it("maps found result to structured metadata fields", () => {
+    const found: MetaplexMetadataResult = {
+      status: "found",
+      name: "My NFT",
+      symbol: "MNFT",
+      uri: "https://example.com/nft.json",
+      seller_fee_basis_points: 500,
+      creators: [{ address: "Creator111", verified: true, share: 100 }],
+      token_standard: "NonFungible",
+      collection: { verified: true, key: "Collection111" },
+      is_collection: false,
+      primary_sale_happened: true,
+      is_mutable: true,
+    };
+
+    const result = buildMetaplexMetadataField(found);
+
+    expect(result).toEqual({
+      name: "My NFT",
+      symbol: "MNFT",
+      uri: "https://example.com/nft.json",
+      seller_fee_basis_points: 500,
+      creators: [{ address: "Creator111", verified: true, share: 100 }],
+      token_standard: "NonFungible",
+      collection: { verified: true, key: "Collection111" },
+      is_collection: false,
+      primary_sale_happened: true,
+      is_mutable: true,
+    });
+  });
+
+  it("handles found result with null optional fields", () => {
+    const found: MetaplexMetadataResult = {
+      status: "found",
+      name: "Fungible Token",
+      symbol: "FT",
+      uri: "https://example.com/ft.json",
+      seller_fee_basis_points: 0,
+      creators: null,
+      token_standard: "Fungible",
+      collection: null,
+      is_collection: false,
+      primary_sale_happened: false,
+      is_mutable: true,
+    };
+
+    const result = buildMetaplexMetadataField(found);
+
+    expect(result).toMatchObject({
+      name: "Fungible Token",
+      token_standard: "Fungible",
+      creators: null,
+      collection: null,
+    });
+  });
+});


### PR DESCRIPTION
## Description

This is part of a multi-PR to port the `inspect_entity` tool from `solana-explorer-mcp` into `solana-mcp-official`, giving the MCP server on-chain data inspection alongside its existing documentation/RAG tools.


## Roadmap

- [x] **Step 0 — Infrastructure Prep**: Pin MCP SDK `1.27.1`, bump `maxDuration` to 120, bump `@vercel/mcp-adapter` to `^1.0.0`
- [x] **Step 1 — Foundation**: `lib/config.ts` (unified config, Zod v3), `lib/observability/logger.ts` (minimal JSON logger), `lib/solana/types.ts`, `constants.ts`, `parse-helpers.ts`, `errors.ts`, `timeout.ts` + unit tests
- [x] **Step 2 — RPC Layer + Account Normalizer**: `lib/solana/rpc.ts`, `account-normalizer.ts` + dep `@solana/kit ^6.4.0` + tests
- [x] **Step 3 — Classifier + Account-Kind Builders + Router**: `inspect-entity-classifier.ts`, `inspect-entity-account-router.ts`, 18 account-kind builders under `lib/solana/account-kinds/` + tests
- [x] **Step 4 — Wire Up Tool (Accounts, Stub Enrichment)**: `lib/solana/inspect-entity.ts`, `lib/tools/inspectEntityTools.ts`, expand `SolanaTool` type with `annotations` + `ZodObject` support, register in `lib/index.ts` + integration tests
- [ ] **Step 5 — Transactions + All Enrichment Resolvers**: Transaction normaliser + payload builder, all 15 resolver files under `lib/solana/resolvers/`, `anchor.ts`, embedded IDLs + deps `@coral-xyz/anchor ^0.32.1`, `@solana-program/program-metadata ^0.5.1` + tests
- [ ] **Step 6 — Analytics, Config Migration, Polish**: Analytics logging for inspect tool, migrate remaining `process.env` to config, E2E tests, `.env.example` update

## Changes in this PR

### Step(s) covered

Step 4