### PR TITLE
feat: migrate MCP to Databricks (retrieval + analytics + Apps deploy)

### DIFF
--- a/.databricksignore
+++ b/.databricksignore
@@ -1,0 +1,17 @@
+node_modules/
+dist/
+coverage/
+.git/
+.env
+.env.*
+!.env.example
+tests/
+monitoring/
+public/
+*.log
+.DS_Store
+pnpm-lock.yaml
+# `prod.yml` holds variable values for `databricks bundle deploy`; never
+# upload it to the workspace.
+prod.yml
+prod.yaml

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,16 @@
 REDIS_URL=
 INKEEP_API_KEY=
 POSTGRES_URL=
+
+# Databricks migration. When USE_DATABRICKS=1, tools + analytics route through
+# Databricks Vector Search + SQL warehouse instead of Inkeep + Neon.
+# Inside a Databricks App, HOST + CLIENT_ID + CLIENT_SECRET are auto-injected;
+# set DATABRICKS_TOKEN only for local dev / non-App deployments.
+USE_DATABRICKS=
+DATABRICKS_HOST=https://your-workspace.cloud.databricks.com
+DATABRICKS_TOKEN=
+DATABRICKS_CLIENT_ID=
+DATABRICKS_CLIENT_SECRET=
+DATABRICKS_VS_INDEX=<catalog>.<schema>.docs_chunks_idx
+DATABRICKS_WAREHOUSE_ID=<warehouse-id>
+DATABRICKS_ANALYTICS_SCHEMA=<catalog>.<schema>

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,14 @@ dist/
 coverage/
 .pnpm-store/
 .mcp.json
+
+# Deployment-specific Databricks App manifest — real catalog/warehouse/index
+# values. Committed template lives at app.yaml; prod.yml overrides locally.
+prod.yml
+prod.yaml
+
+# Deployment-specific Lakeview dashboard with real catalog/schema in datasets.
+# Committed template: dashboards/solana_mcp.example.lvdash.json
+dashboards/solana_mcp.lvdash.json
+
+eval/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,30 @@
+set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
+
+app := "solana-mcp"
+prod_yml := "prod.yml"
+
 fmt:
     pnpm format
     pnpm lint:fix
 
 test:
     pnpm test
+
+# Deploy app + ingestion job via Databricks Asset Bundle. Reads gitignored
+# `prod.yml` for variable values (schema, warehouse_id, vs_index, ...).
+deploy:
+    @if [ ! -f "{{prod_yml}}" ]; then echo "missing {{prod_yml}} at repo root — see databricks.yml for required variables"; exit 1; fi
+    @if [ ! -f "dashboards/solana_mcp.lvdash.json" ]; then echo "missing dashboards/solana_mcp.lvdash.json — cp dashboards/solana_mcp.example.lvdash.json dashboards/solana_mcp.lvdash.json and set catalog/schema per dataset"; exit 1; fi
+    pnpm build
+    # Enhanced pipeline: runs bundle deploy (job + app + dashboard resources)
+    # then creates a new app deployment with the bundle's config.env applied.
+    # Dashboard file has catalog/schema per dataset (gitignored real values).
+    DATABRICKS_BUNDLE_ENGINE=direct databricks apps deploy --target prod
+
+# Validate bundle config without deploying.
+bundle-validate:
+    databricks bundle validate --target prod
+
+# Tail recent app logs.
+logs-app:
+    databricks apps logs {{app}} --tail-lines 100

--- a/api/start.ts
+++ b/api/start.ts
@@ -1,0 +1,77 @@
+import express, { type Request as ExpressRequest, type Response as ExpressResponse } from "express";
+import rawBody from "raw-body";
+import * as dotenv from "dotenv";
+
+import { createMcp } from "../lib";
+
+dotenv.config();
+
+const handler = createMcp();
+const app = express();
+
+app.get("/healthz", (_req: ExpressRequest, res: ExpressResponse) => {
+  res.status(200).json({ ok: true });
+});
+
+app.all(/.*/, async (req: ExpressRequest, res: ExpressResponse) => {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host ?? "localhost"}`);
+    const method = req.method;
+    const webHeaders = new Headers();
+    for (const [name, value] of Object.entries(req.headers)) {
+      if (value === undefined) continue;
+      if (Array.isArray(value)) webHeaders.set(name, value.join(", "));
+      else webHeaders.set(name, String(value));
+    }
+
+    let body: Uint8Array | undefined;
+    if (method !== "GET" && method !== "HEAD") {
+      const buf = await rawBody(req);
+      if (buf.length > 0) {
+        body = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+      }
+    }
+
+    const webReq = new Request(url, {
+      method,
+      headers: webHeaders,
+      body: body as BodyInit | undefined,
+    });
+
+    const webRes = await handler(webReq);
+
+    res.status(webRes.status);
+    webRes.headers.forEach((value, key) => {
+      res.setHeader(key, value);
+    });
+
+    if (!webRes.body) {
+      res.end();
+      return;
+    }
+
+    const reader = webRes.body.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        res.write(value);
+      }
+    } finally {
+      reader.releaseLock();
+      res.end();
+    }
+  } catch (err) {
+    console.error("[start] handler error:", err);
+    if (!res.headersSent) {
+      res.status(500).json({ error: "Internal server error" });
+    } else {
+      res.end();
+    }
+  }
+});
+
+const port = Number(process.env.DATABRICKS_APP_PORT ?? process.env.PORT ?? 3000);
+app.listen(port, () => {
+  console.warn(`[start] solana-mcp listening on :${port}`);
+});

--- a/dashboards/solana_mcp.example.lvdash.json
+++ b/dashboards/solana_mcp.example.lvdash.json
@@ -1,0 +1,449 @@
+{
+  "datasets": [
+    {
+      "name": "corpus_totals",
+      "displayName": "Corpus totals",
+      "queryLines": [
+        "SELECT\n",
+        "  count(*) AS total_chunks,\n",
+        "  count(DISTINCT url) AS distinct_urls,\n",
+        "  count(DISTINCT source_id) AS sources,\n",
+        "  max(fetched_at) AS last_fetch\n",
+        "FROM docs_chunks"
+      ]
+    },
+    {
+      "name": "chunks_per_source",
+      "displayName": "Chunks per source",
+      "queryLines": [
+        "SELECT source_id, count(*) AS chunks\n",
+        "FROM docs_chunks\n",
+        "GROUP BY source_id\n",
+        "ORDER BY chunks DESC"
+      ]
+    },
+    {
+      "name": "freshness",
+      "displayName": "Corpus freshness (weekly)",
+      "queryLines": [
+        "SELECT date_trunc('week', fetched_at) AS week, count(*) AS chunks\n",
+        "FROM docs_chunks\n",
+        "GROUP BY 1 ORDER BY 1"
+      ]
+    },
+    {
+      "name": "tool_calls_daily",
+      "displayName": "Tool calls per day",
+      "queryLines": [
+        "SELECT date(timestamp) AS day, tool_name, count(*) AS calls\n",
+        "FROM mcp_tool_calls\n",
+        "WHERE row_type = 'request'\n",
+        "GROUP BY 1, 2 ORDER BY 1"
+      ]
+    },
+    {
+      "name": "top_queries",
+      "displayName": "Top 50 queries",
+      "queryLines": [
+        "SELECT\n",
+        "  coalesce(\n",
+        "    get_json_object(arguments, '$.query'),\n",
+        "    get_json_object(arguments, '$.question')\n",
+        "  ) AS q,\n",
+        "  count(*) AS calls\n",
+        "FROM mcp_tool_calls\n",
+        "WHERE row_type = 'request'\n",
+        "GROUP BY 1 ORDER BY 2 DESC LIMIT 50"
+      ]
+    },
+    {
+      "name": "clients",
+      "displayName": "Clients",
+      "queryLines": [
+        "SELECT client_name, client_version, count(*) AS handshakes\n",
+        "FROM mcp_initializations\n",
+        "GROUP BY 1, 2 ORDER BY 3 DESC"
+      ]
+    }
+  ],
+  "pages": [
+    {
+      "name": "overview",
+      "displayName": "Overview",
+      "layout": [
+        {
+          "widget": {
+            "name": "hdr_corpus",
+            "textbox_spec": "# Corpus\n\nDocs_chunks Delta table. Fed daily by `solana-mcp-ingest` job."
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "width": 6,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "counter_total_chunks",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "corpus_totals",
+                  "fields": [
+                    {
+                      "name": "total_chunks",
+                      "expression": "`total_chunks`"
+                    }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": {
+                "value": {
+                  "fieldName": "total_chunks",
+                  "displayName": "Total chunks"
+                }
+              },
+              "frame": {
+                "title": "Total chunks",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 1,
+            "width": 2,
+            "height": 3
+          }
+        },
+        {
+          "widget": {
+            "name": "counter_distinct_urls",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "corpus_totals",
+                  "fields": [
+                    {
+                      "name": "distinct_urls",
+                      "expression": "`distinct_urls`"
+                    }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": {
+                "value": {
+                  "fieldName": "distinct_urls",
+                  "displayName": "Distinct URLs"
+                }
+              },
+              "frame": {
+                "title": "Distinct URLs",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 2,
+            "y": 1,
+            "width": 2,
+            "height": 3
+          }
+        },
+        {
+          "widget": {
+            "name": "counter_sources",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "corpus_totals",
+                  "fields": [
+                    {
+                      "name": "sources",
+                      "expression": "`sources`"
+                    }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": {
+                "value": {
+                  "fieldName": "sources",
+                  "displayName": "Sources"
+                }
+              },
+              "frame": {
+                "title": "Sources",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 4,
+            "y": 1,
+            "width": 2,
+            "height": 3
+          }
+        },
+        {
+          "widget": {
+            "name": "bar_chunks_per_source",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "chunks_per_source",
+                  "fields": [
+                    {
+                      "name": "source_id",
+                      "expression": "`source_id`"
+                    },
+                    {
+                      "name": "chunks",
+                      "expression": "`chunks`"
+                    }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "chunks",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Chunks"
+                },
+                "y": {
+                  "fieldName": "source_id",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "Source"
+                }
+              },
+              "frame": {
+                "title": "Chunks per source",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 4,
+            "width": 6,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "hdr_traffic",
+            "textbox_spec": "# Traffic"
+          },
+          "position": {
+            "x": 0,
+            "y": 10,
+            "width": 6,
+            "height": 1
+          }
+        },
+        {
+          "widget": {
+            "name": "line_tool_calls_daily",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "tool_calls_daily",
+                  "fields": [
+                    {
+                      "name": "day",
+                      "expression": "`day`"
+                    },
+                    {
+                      "name": "tool_name",
+                      "expression": "`tool_name`"
+                    },
+                    {
+                      "name": "calls",
+                      "expression": "`calls`"
+                    }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": {
+                  "fieldName": "day",
+                  "scale": {
+                    "type": "temporal"
+                  },
+                  "displayName": "Day"
+                },
+                "y": {
+                  "fieldName": "calls",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Calls"
+                },
+                "color": {
+                  "fieldName": "tool_name",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "Tool"
+                }
+              },
+              "frame": {
+                "title": "Tool calls per day",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 11,
+            "width": 6,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "table_top_queries",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "top_queries",
+                  "fields": [
+                    {
+                      "name": "q",
+                      "expression": "`q`"
+                    },
+                    {
+                      "name": "calls",
+                      "expression": "`calls`"
+                    }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 1,
+              "widgetType": "table",
+              "encodings": {
+                "columns": [
+                  {
+                    "fieldName": "q",
+                    "displayName": "Query"
+                  },
+                  {
+                    "fieldName": "calls",
+                    "displayName": "Calls"
+                  }
+                ]
+              },
+              "frame": {
+                "title": "Top queries",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 17,
+            "width": 6,
+            "height": 6
+          }
+        },
+        {
+          "widget": {
+            "name": "bar_clients",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "clients",
+                  "fields": [
+                    {
+                      "name": "client_name",
+                      "expression": "`client_name`"
+                    },
+                    {
+                      "name": "handshakes",
+                      "expression": "`handshakes`"
+                    }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": {
+                  "fieldName": "handshakes",
+                  "scale": {
+                    "type": "quantitative"
+                  },
+                  "displayName": "Handshakes"
+                },
+                "y": {
+                  "fieldName": "client_name",
+                  "scale": {
+                    "type": "categorical"
+                  },
+                  "displayName": "Client"
+                }
+              },
+              "frame": {
+                "title": "Clients",
+                "showTitle": true
+              }
+            }
+          },
+          "position": {
+            "x": 0,
+            "y": 23,
+            "width": 6,
+            "height": 6
+          }
+        }
+      ]
+    }
+  ],
+  "uiSettings": {
+    "theme": {
+      "widgetHeaderAlignment": "ALIGN_LEFT"
+    }
+  }
+}

--- a/databricks.yml
+++ b/databricks.yml
@@ -1,0 +1,85 @@
+bundle:
+  name: solana-mcp
+
+# Optional gitignored include supplies target variable values. Matches zero
+# or one file; if missing, `databricks bundle deploy` will complain about
+# unresolved variables and fail clearly.
+include:
+  - prod.yml
+
+# All deployment-specific values come through these variables. Supply real
+# values in a gitignored `prod.yml` or per-invocation with `--var`.
+variables:
+  catalog:
+    description: Unity Catalog catalog holding MCP tables.
+  schema:
+    description: Schema inside the catalog (combined path becomes `${catalog}.${schema}`).
+  warehouse_id:
+    description: SQL warehouse id for analytics inserts.
+  vs_endpoint:
+    description: Vector Search endpoint name.
+  vs_index:
+    description: Fully-qualified Vector Search index.
+  notebook_sources_path:
+    description: Workspace path to ingestion/sources.yaml once uploaded.
+  bundle_root:
+    description: Workspace path prefix where the bundle artifacts live.
+    default: /Workspace/.bundle/solana-mcp/${bundle.target}
+
+targets:
+  prod:
+    mode: production
+    default: true
+    # Workspace host resolved from the active `databricks auth` profile or
+    # the DATABRICKS_HOST env var — not committed here.
+    workspace:
+      root_path: ${var.bundle_root}
+
+resources:
+  apps:
+    solana_mcp:
+      name: solana-mcp
+      description: "Solana MCP server — Databricks-hosted TS MCP handler."
+      source_code_path: ${workspace.file_path}
+      config:
+        command:
+          - node
+          - dist/start.js
+        env:
+          - name: USE_DATABRICKS
+            value: "1"
+          - name: DATABRICKS_VS_INDEX
+            value: ${var.vs_index}
+          - name: DATABRICKS_WAREHOUSE_ID
+            value: ${var.warehouse_id}
+          - name: DATABRICKS_ANALYTICS_SCHEMA
+            value: ${var.catalog}.${var.schema}
+
+  jobs:
+    solana_mcp_ingest:
+      name: solana-mcp-ingest
+      description: "Daily corpus refresh — crawl sources, MERGE into Delta, trigger VS sync."
+      tasks:
+        - task_key: crawl
+          notebook_task:
+            notebook_path: ./ingestion/crawl_and_index.py
+            base_parameters:
+              target_table: ${var.catalog}.${var.schema}.docs_chunks
+              vs_endpoint: ${var.vs_endpoint}
+              vs_index: ${var.vs_index}
+              sources_path: ${var.notebook_sources_path}
+              max_pages_per_source: "2000"
+      schedule:
+        quartz_cron_expression: "0 0 9 * * ?"  # daily 09:00 UTC
+        timezone_id: UTC
+        pause_status: UNPAUSED
+      email_notifications:
+        on_failure: []  # set via var file if desired
+
+  dashboards:
+    solana_mcp_dashboard:
+      display_name: Solana MCP
+      # Gitignored file with real catalog/schema per dataset. See
+      # dashboards/solana_mcp.example.lvdash.json for the template.
+      file_path: ./dashboards/solana_mcp.lvdash.json
+      warehouse_id: ${var.warehouse_id}

--- a/ingestion/crawl_and_index.py
+++ b/ingestion/crawl_and_index.py
@@ -1,0 +1,558 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Solana MCP — Doc Ingestion
+# MAGIC
+# MAGIC Reads `sources.yaml`, crawls docs, chunks markdown, MERGEs into the
+# MAGIC Delta table pointed to by the `target_table` widget. The Vector Search
+# MAGIC Delta-Sync index named by the `vs_index` widget picks up changes on
+# MAGIC the next sync.
+# MAGIC
+# MAGIC **Run-as**: service principal with `USE CATALOG` + `USE SCHEMA` on the
+# MAGIC target schema, `SELECT` + `MODIFY` on the target table, `CAN USE` on
+# MAGIC the Vector Search endpoint, and outbound internet.
+
+# COMMAND ----------
+
+# MAGIC %pip install --quiet httpx beautifulsoup4 pyyaml markdown-it-py databricks-vectorsearch
+# MAGIC dbutils.library.restartPython()
+
+# COMMAND ----------
+
+import hashlib
+import logging
+import os
+import re
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+from urllib.parse import urljoin, urlparse
+from xml.etree import ElementTree as ET
+
+import httpx
+import yaml
+from bs4 import BeautifulSoup
+from markdown_it import MarkdownIt
+
+from pyspark.sql import Row
+from pyspark.sql.types import (
+    ArrayType, StringType, StructField, StructType, TimestampType,
+)
+from delta.tables import DeltaTable
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("ingest")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Configuration
+
+# COMMAND ----------
+
+# Notebook widgets — override at job run time
+# Workspace-specific values are passed via Job `base_parameters` (which
+# populate widgets). Defaults are placeholders so nothing about a particular
+# deployment leaks into the public repo. See ingestion/job.example.yml.
+PLACEHOLDER_PREFIX = "<"
+
+dbutils.widgets.text("target_table", "<catalog>.<schema>.docs_chunks")
+dbutils.widgets.text("sources_path", "<workspace-path>/sources.yaml")
+dbutils.widgets.text("vs_endpoint", "<vector-search-endpoint>")
+dbutils.widgets.text("vs_index", "<catalog>.<schema>.docs_chunks_idx")
+dbutils.widgets.text("only_sources", "", "comma-separated source ids to restrict run")
+dbutils.widgets.text("max_pages_per_source", "2000")
+
+TARGET_TABLE = dbutils.widgets.get("target_table")
+SOURCES_PATH = dbutils.widgets.get("sources_path")
+VS_ENDPOINT = dbutils.widgets.get("vs_endpoint")
+VS_INDEX = dbutils.widgets.get("vs_index")
+ONLY_SOURCES = {s.strip() for s in dbutils.widgets.get("only_sources").split(",") if s.strip()}
+MAX_PAGES = int(dbutils.widgets.get("max_pages_per_source"))
+
+for _name, _value in {
+    "target_table": TARGET_TABLE,
+    "sources_path": SOURCES_PATH,
+    "vs_endpoint": VS_ENDPOINT,
+    "vs_index": VS_INDEX,
+}.items():
+    if _value.startswith(PLACEHOLDER_PREFIX):
+        raise ValueError(
+            f"widget `{_name}` still holds placeholder `{_value}`. "
+            "Set it via Job base_parameters or the widget bar before running.",
+        )
+
+# Token budget approximated as 4 chars/token (English avg). Good enough for
+# chunk sizing; embedding model does its own tokenization. Avoids native deps.
+CHUNK_CHARS = 2000        # ~500 tokens
+CHUNK_OVERLAP_CHARS = 200 # ~50 tokens
+HTTP_TIMEOUT_S = 30
+USER_AGENT = "solana-mcp-indexer/1.0 (+https://github.com/solana-foundation)"
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Data model
+
+# COMMAND ----------
+
+CHUNK_SCHEMA = StructType([
+    StructField("id", StringType(), nullable=False),
+    StructField("source_id", StringType()),
+    StructField("url", StringType()),
+    StructField("title", StringType()),
+    StructField("heading_path", ArrayType(StringType())),
+    StructField("content", StringType()),
+    StructField("content_hash", StringType()),
+    StructField("fetched_at", TimestampType()),
+    StructField("updated_at", TimestampType()),
+])
+
+@dataclass
+class Chunk:
+    id: str
+    source_id: str
+    url: str
+    title: Optional[str]
+    heading_path: list[str]
+    content: str
+    content_hash: str
+    fetched_at: datetime
+    updated_at: datetime
+
+    def as_row(self) -> Row:
+        return Row(**self.__dict__)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## HTTP client
+
+# COMMAND ----------
+
+def http_client() -> httpx.Client:
+    return httpx.Client(
+        timeout=HTTP_TIMEOUT_S,
+        follow_redirects=True,
+        headers={"User-Agent": USER_AGENT, "Accept": "text/html,application/xhtml+xml,application/xml,application/json;q=0.9,*/*;q=0.8"},
+    )
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Chunking
+
+# COMMAND ----------
+
+_MD = MarkdownIt()
+
+def split_by_chars(text: str, max_chars: int = CHUNK_CHARS, overlap: int = CHUNK_OVERLAP_CHARS) -> list[str]:
+    text = text.strip()
+    if not text:
+        return []
+    if len(text) <= max_chars:
+        return [text]
+    out = []
+    step = max_chars - overlap
+    for i in range(0, len(text), step):
+        out.append(text[i:i + max_chars])
+        if i + max_chars >= len(text):
+            break
+    return out
+
+def markdown_sections(md_text: str) -> list[tuple[list[str], str]]:
+    """Yield (heading_path, section_body) by walking markdown headings."""
+    tokens = _MD.parse(md_text)
+    sections: list[tuple[list[str], list[str]]] = []
+    path: list[tuple[int, str]] = []  # (level, text)
+    buf: list[str] = []
+    current_path: list[str] = []
+
+    def flush():
+        if buf and "".join(buf).strip():
+            sections.append((list(current_path), "\n".join(buf).strip()))
+
+    i = 0
+    while i < len(tokens):
+        t = tokens[i]
+        if t.type == "heading_open":
+            flush()
+            buf.clear()
+            level = int(t.tag[1])
+            inline = tokens[i + 1].content if i + 1 < len(tokens) else ""
+            while path and path[-1][0] >= level:
+                path.pop()
+            path.append((level, inline))
+            current_path = [p[1] for p in path]
+            i += 3  # heading_open, inline, heading_close
+            continue
+        if t.type == "inline":
+            buf.append(t.content)
+        elif t.type == "fence":
+            buf.append(f"```{t.info or ''}\n{t.content}```")
+        elif t.type == "code_block":
+            buf.append(t.content)
+        i += 1
+    flush()
+    return [(p, b) for p, b in sections if b.strip()]
+
+def chunks_from_markdown(source_id: str, url: str, title: Optional[str], md_text: str, now: datetime) -> list[Chunk]:
+    out: list[Chunk] = []
+    sections = markdown_sections(md_text) or [([], md_text)]
+    for heading_path, body in sections:
+        for piece in split_by_chars(body):
+            content_hash = hashlib.sha256(piece.encode("utf-8")).hexdigest()
+            cid = hashlib.sha256(f"{source_id}|{url}|{'/'.join(heading_path)}|{content_hash}".encode()).hexdigest()
+            out.append(Chunk(
+                id=cid,
+                source_id=source_id,
+                url=url,
+                title=title or (heading_path[0] if heading_path else url),
+                heading_path=heading_path,
+                content=piece,
+                content_hash=content_hash,
+                fetched_at=now,
+                updated_at=now,
+            ))
+    return out
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Web crawler
+
+# COMMAND ----------
+
+def fetch_sitemap(client: httpx.Client, sitemap_url: str) -> list[str]:
+    try:
+        r = client.get(sitemap_url)
+        r.raise_for_status()
+    except httpx.HTTPError as e:
+        log.warning("sitemap fetch failed %s: %s", sitemap_url, e)
+        return []
+    urls: list[str] = []
+    try:
+        root = ET.fromstring(r.text)
+    except ET.ParseError:
+        return []
+    ns = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    for sm in root.findall("sm:sitemap", ns):
+        loc = sm.findtext("sm:loc", namespaces=ns)
+        if loc:
+            urls.extend(fetch_sitemap(client, loc))
+    for url in root.findall("sm:url", ns):
+        loc = url.findtext("sm:loc", namespaces=ns)
+        if loc:
+            urls.append(loc)
+    return urls
+
+def extract_article(html: str) -> tuple[str, str]:
+    """Return (title, markdown-ish text) from HTML."""
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup(["script", "style", "nav", "footer", "header", "aside", "noscript"]):
+        tag.decompose()
+    title = (soup.title.string.strip() if soup.title and soup.title.string else "") or ""
+    main = soup.find("main") or soup.find("article") or soup.body or soup
+    text = main.get_text("\n", strip=True)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return title, text
+
+def url_matches_include(url: str, patterns: list[str]) -> bool:
+    if not patterns:
+        return True
+    lowered = url.lower()
+    return any(p.lower() in lowered for p in patterns)
+
+def url_matches_exclude(url: str, patterns: list[str]) -> bool:
+    if not patterns:
+        return False
+    lowered = url.lower()
+    return any(p.lower() in lowered for p in patterns)
+
+# Generic non-English locale path segments commonly used by docs platforms
+# (Fumadocs, Nextra, Docusaurus i18n, Mintlify). English pages live at root
+# or under `/en/`, so these are always safe to skip.
+LOCALE_PATTERN = re.compile(
+    r"/(de|es|fr|ja|ko|ru|zh|zh-cn|zh-tw|pt|pt-br|it|tr|vi|id|ar|hi|th|pl|nl|cs|uk|sv|no|da|fi|el|ro|hu|he|bn|uz|tl|sr|hr|bg|ca|sk|sl|lt|lv|et|ms|fa|ur)(/|$)",
+    re.IGNORECASE,
+)
+
+def is_non_en_locale(url: str) -> bool:
+    path = urlparse(url).path
+    return bool(LOCALE_PATTERN.search(path))
+
+def normalize_url(url: str) -> str:
+    """Canonical URL: force https, lowercase host, strip trailing slash + fragment."""
+    p = urlparse(url.split("#", 1)[0])
+    netloc = p.netloc.lower()
+    if not netloc:
+        return url
+    scheme = "https"
+    path = p.path.rstrip("/") or "/"
+    query = f"?{p.query}" if p.query else ""
+    return f"{scheme}://{netloc}{path}{query}"
+
+def crawl_web(source: dict, client: httpx.Client, now: datetime) -> list[Chunk]:
+    source_id = source["id"]
+    includes = source.get("url_include") or []
+    excludes = source.get("url_exclude") or []
+    skip_locales = source.get("skip_locales", True)
+
+    def accept(url: str) -> bool:
+        if not url_matches_include(url, includes):
+            return False
+        if url_matches_exclude(url, excludes):
+            return False
+        if skip_locales and is_non_en_locale(url):
+            return False
+        return True
+
+    seen: set[str] = set()
+    urls: list[str] = []
+
+    for sm in source.get("sitemaps") or []:
+        urls.extend(fetch_sitemap(client, sm))
+    for u in source.get("ingest_urls") or []:
+        urls.append(u)
+    start_urls = source.get("start_urls") or []
+    if not urls and start_urls:
+        urls = list(start_urls)  # BFS-lite from start urls
+        base_hosts = {urlparse(u).netloc for u in start_urls}
+        queue = list(start_urls)
+        while queue and len(urls) < MAX_PAGES:
+            cur = queue.pop(0)
+            if cur in seen:
+                continue
+            seen.add(cur)
+            try:
+                r = client.get(cur)
+                if r.status_code != 200 or "text/html" not in r.headers.get("content-type", ""):
+                    continue
+            except httpx.HTTPError:
+                continue
+            soup = BeautifulSoup(r.text, "html.parser")
+            for a in soup.find_all("a", href=True):
+                nxt = normalize_url(urljoin(cur, a["href"]))
+                if urlparse(nxt).netloc in base_hosts and nxt not in seen and nxt.startswith("http"):
+                    if nxt not in urls and accept(nxt):
+                        urls.append(nxt)
+                        queue.append(nxt)
+
+    # Normalize + deduplicate all collected URLs (sitemap + ingest + BFS)
+    normalized: list[str] = []
+    dedupe: set[str] = set()
+    for u in urls:
+        n = normalize_url(u)
+        if n in dedupe:
+            continue
+        dedupe.add(n)
+        normalized.append(n)
+    urls = normalized
+
+    before = len(urls)
+    urls = [u for u in urls if accept(u)]
+    if before != len(urls):
+        log.info("source %s: filters dropped %d → %d urls", source_id, before, len(urls))
+
+    urls = urls[:MAX_PAGES]
+    log.info("source %s: %d urls", source_id, len(urls))
+
+    chunks: list[Chunk] = []
+    for u in urls:
+        if u in seen and not (source.get("sitemaps") or source.get("ingest_urls")):
+            pass  # BFS already visited; refetch fine for content extraction
+        try:
+            r = client.get(u)
+            if r.status_code != 200:
+                continue
+            ctype = r.headers.get("content-type", "")
+            if "text/html" not in ctype:
+                continue
+            title, text = extract_article(r.text)
+            chunks.extend(chunks_from_markdown(source_id, u, title, text, now))
+        except httpx.HTTPError as e:
+            log.warning("fetch %s failed: %s", u, e)
+        time.sleep(0.1)  # light throttle
+    return chunks
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## GitHub crawler (shallow clone)
+
+# COMMAND ----------
+
+GH_DOC_EXTS = {".md", ".mdx"}
+GH_CODE_EXTS = {".rs", ".ts", ".tsx", ".js", ".py", ".go"}
+
+def crawl_github(source: dict, now: datetime) -> list[Chunk]:
+    source_id = source["id"]
+    gh = source["github"]
+    owner, repo = gh["owner"], gh["repo"]
+    include_src = bool(gh.get("include_source_code"))
+    repo_url = f"https://github.com/{owner}/{repo}.git"
+
+    chunks: list[Chunk] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        dst = Path(tmp) / repo
+        try:
+            subprocess.run(
+                ["git", "clone", "--depth", "1", "--filter=blob:none", repo_url, str(dst)],
+                check=True, capture_output=True, text=True,
+            )
+        except subprocess.CalledProcessError as e:
+            log.warning("clone %s failed: %s", repo_url, e.stderr)
+            return chunks
+
+        for f in dst.rglob("*"):
+            if not f.is_file():
+                continue
+            ext = f.suffix.lower()
+            rel = f.relative_to(dst).as_posix()
+            if ext in GH_DOC_EXTS:
+                body = f.read_text(encoding="utf-8", errors="ignore")
+                url = f"https://github.com/{owner}/{repo}/blob/HEAD/{rel}"
+                title = f"{repo}/{rel}"
+                chunks.extend(chunks_from_markdown(source_id, url, title, body, now))
+            elif include_src and ext in GH_CODE_EXTS:
+                body = f.read_text(encoding="utf-8", errors="ignore")
+                if len(body) > 200_000:
+                    continue  # skip giant generated files
+                url = f"https://github.com/{owner}/{repo}/blob/HEAD/{rel}"
+                title = f"{repo}/{rel}"
+                wrapped = f"```{ext.lstrip('.')}\n{body}\n```"
+                chunks.extend(chunks_from_markdown(source_id, url, title, wrapped, now))
+    log.info("source %s: %d chunks", source_id, len(chunks))
+    return chunks
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## OpenAPI crawler
+
+# COMMAND ----------
+
+def crawl_openapi(source: dict, client: httpx.Client, now: datetime) -> list[Chunk]:
+    source_id = source["id"]
+    spec_url = source["spec_url"]
+    citation = source.get("primary_url") or spec_url
+    try:
+        r = client.get(spec_url)
+        r.raise_for_status()
+        spec = r.json()
+    except (httpx.HTTPError, ValueError) as e:
+        log.warning("openapi fetch %s failed: %s", spec_url, e)
+        return []
+
+    chunks: list[Chunk] = []
+    paths = spec.get("paths") or {}
+    for path, methods in paths.items():
+        for method, op in (methods or {}).items():
+            if method.lower() not in {"get", "post", "put", "delete", "patch"}:
+                continue
+            summary = op.get("summary") or ""
+            desc = op.get("description") or ""
+            params = op.get("parameters") or []
+            param_lines = [f"- `{p.get('name')}` ({p.get('in')}): {p.get('description','')}" for p in params]
+            body = f"## {method.upper()} {path}\n\n{summary}\n\n{desc}\n\n### Parameters\n" + "\n".join(param_lines)
+            chunks.extend(chunks_from_markdown(
+                source_id, f"{citation}#{method.upper()}-{path}",
+                f"{method.upper()} {path}", body, now,
+            ))
+    return chunks
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Orchestrator
+
+# COMMAND ----------
+
+def load_sources() -> list[dict]:
+    with open(SOURCES_PATH) as f:
+        doc = yaml.safe_load(f)
+    items = doc.get("sources") or []
+    if ONLY_SOURCES:
+        items = [s for s in items if s["id"] in ONLY_SOURCES]
+    return [s for s in items if s.get("enabled", True)]
+
+def crawl_all(now: datetime) -> list[Chunk]:
+    all_chunks: list[Chunk] = []
+    with http_client() as client:
+        for s in load_sources():
+            kind = s["kind"]
+            log.info("=== crawling %s (%s) ===", s["id"], kind)
+            try:
+                if kind == "web":
+                    all_chunks.extend(crawl_web(s, client, now))
+                elif kind == "github":
+                    all_chunks.extend(crawl_github(s, now))
+                elif kind == "openapi":
+                    all_chunks.extend(crawl_openapi(s, client, now))
+                else:
+                    log.warning("unknown kind %s for %s", kind, s["id"])
+            except Exception as e:
+                log.exception("source %s crashed: %s", s["id"], e)
+    return all_chunks
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Run
+
+# COMMAND ----------
+
+now = datetime.now(timezone.utc)
+chunks = crawl_all(now)
+log.info("total chunks: %d", len(chunks))
+
+if not chunks:
+    raise RuntimeError("no chunks produced — check source errors above")
+
+df = spark.createDataFrame([c.as_row() for c in chunks], schema=CHUNK_SCHEMA)
+df = df.dropDuplicates(["id"])
+log.info("df row count: %d", df.count())
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## MERGE into Delta
+
+# COMMAND ----------
+
+target = DeltaTable.forName(spark, TARGET_TABLE)
+(target.alias("t")
+    .merge(df.alias("s"), "t.id = s.id")
+    .whenMatchedUpdate(
+        condition="t.content_hash <> s.content_hash",
+        set={
+            "content": "s.content",
+            "content_hash": "s.content_hash",
+            "title": "s.title",
+            "heading_path": "s.heading_path",
+            "url": "s.url",
+            "updated_at": "s.updated_at",
+        },
+    )
+    .whenNotMatchedInsertAll()
+    .execute())
+
+post = spark.sql(f"SELECT count(*) AS n FROM {TARGET_TABLE}").collect()[0]["n"]
+log.info("target table %s now holds %d rows", TARGET_TABLE, post)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Trigger Vector Search sync
+
+# COMMAND ----------
+
+from databricks.vector_search.client import VectorSearchClient
+
+vsc = VectorSearchClient(disable_notice=True)
+idx = vsc.get_index(index_name=VS_INDEX, endpoint_name=VS_ENDPOINT)
+idx.sync()
+log.info("triggered sync on %s", VS_INDEX)

--- a/ingestion/sources.yaml
+++ b/ingestion/sources.yaml
@@ -1,0 +1,527 @@
+# Solana MCP ingestion corpus
+# Schema consumed by ingestion/crawl_and_index.py.
+#
+# kind: github | web | openapi
+#   github: clones repo shallow, ingests .md/.mdx (+ source code if include_source_code)
+#   web:    crawls via sitemaps/start_urls/ingest_urls, extracts article-body text
+#   openapi: fetches JSON spec, chunks by operation
+# enabled: false → skip this source on job run (use to gate noisy/huge sources)
+# url_include: optional list of case-insensitive substrings. Applied after URL
+#   collection (sitemap/BFS/ingest_urls) — URL is kept only if it contains at
+#   least one substring. Use for multi-chain doc sites to filter to Solana-only.
+
+sources:
+  # --- Core Solana docs / SDKs ---
+  - id: solana-docs
+    name: Solana Docs (solana.com/docs)
+    kind: web
+    enabled: true
+    primary_url: https://solana.com/docs
+    start_urls:
+      - https://solana.com/docs
+
+  - id: anchor-docs
+    name: Solana > Anchor Docs
+    kind: web
+    enabled: true
+    primary_url: https://www.anchor-lang.com/docs
+    start_urls:
+      - https://www.anchor-lang.com/docs
+
+  - id: solana-kit-docs
+    name: Solana Kit Docs
+    kind: web
+    enabled: true
+    primary_url: https://www.solanakit.com
+    start_urls:
+      - https://www.solanakit.com
+
+  - id: solana-gill-docs
+    name: Solana > Gill Docs
+    kind: web
+    enabled: true
+    primary_url: https://gill.site/docs
+    start_urls:
+      - https://gill.site/docs
+
+  - id: solana-program-site
+    name: Solana Program (solana-program.com)
+    kind: web
+    enabled: true
+    primary_url: https://www.solana-program.com
+    start_urls:
+      - https://www.solana-program.com
+      - https://www.solana-program.com/docs
+
+  - id: solana-mobile-docs
+    name: Solana Mobile Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.solanamobile.com
+    sitemaps:
+      - https://docs.solanamobile.com/sitemap.xml
+
+  - id: firedancer-docs
+    name: Firedancer Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.firedancer.io
+    start_urls:
+      - https://docs.firedancer.io
+
+  - id: zk-compression-docs
+    name: ZK Compression Docs
+    kind: web
+    enabled: true
+    primary_url: https://www.zkcompression.com
+    sitemaps:
+      - https://www.zkcompression.com/sitemap.xml
+
+  # --- Rust / Python / Java SDK docs ---
+  - id: solana-program-rust-docs
+    name: solana_program - Rust Docs (docs.rs)
+    kind: web
+    enabled: true
+    primary_url: https://docs.rs/solana-program/2.1.18/solana_program
+    ingest_urls:
+      - https://docs.rs/solana-program/2.1.18/solana_program
+
+  - id: solders-docs
+    name: Solders Docs
+    kind: web
+    enabled: true
+    primary_url: https://kevinheavey.github.io/solders/
+    start_urls:
+      - https://kevinheavey.github.io/solders/
+
+  - id: anchorpy-docs
+    name: AnchorPy Docs
+    kind: web
+    enabled: true
+    primary_url: https://kevinheavey.github.io/anchorpy/
+    start_urls:
+      - https://kevinheavey.github.io/anchorpy/
+
+  - id: solana-py-docs
+    name: Solana.py > Solana Python SDK Docs
+    kind: web
+    enabled: true
+    primary_url: https://michaelhly.com/solana-py/
+    start_urls:
+      - https://michaelhly.com/solana-py/
+
+  - id: sava-java-sdk-docs
+    name: Sava > Solana Java SDK Docs
+    kind: web
+    enabled: true
+    primary_url: https://sava.software
+    sitemaps:
+      - https://sava.software/sitemap.xml
+
+  # --- Core GitHub repos (READMEs + source) ---
+  - id: gh-anchor
+    name: GitHub coral-xyz/anchor
+    kind: github
+    enabled: true
+    primary_url: https://github.com/coral-xyz/anchor
+    github: { owner: coral-xyz, repo: anchor, include_readmes: true, include_source_code: true }
+
+  - id: gh-kit
+    name: GitHub anza-xyz/kit (Solana JS SDK)
+    kind: github
+    enabled: true
+    primary_url: https://github.com/anza-xyz/kit
+    github: { owner: anza-xyz, repo: kit, include_readmes: true, include_source_code: true }
+
+  - id: gh-solana-sdk
+    name: GitHub anza-xyz/solana-sdk (Rust SDK)
+    kind: github
+    enabled: true
+    primary_url: https://github.com/anza-xyz/solana-sdk
+    github: { owner: anza-xyz, repo: solana-sdk, include_readmes: true, include_source_code: true }
+
+  - id: gh-web3js
+    name: GitHub solana-foundation/solana-web3.js (v1.x)
+    kind: github
+    enabled: true
+    primary_url: https://github.com/solana-foundation/solana-web3.js
+    github: { owner: solana-foundation, repo: solana-web3.js, include_readmes: true, include_source_code: true }
+
+  - id: gh-pinocchio
+    name: GitHub anza-xyz/pinocchio
+    kind: github
+    enabled: true
+    primary_url: https://github.com/anza-xyz/pinocchio
+    github: { owner: anza-xyz, repo: pinocchio, include_readmes: true, include_source_code: true }
+
+  - id: gh-mollusk
+    name: GitHub anza-xyz/mollusk
+    kind: github
+    enabled: true
+    primary_url: https://github.com/anza-xyz/mollusk
+    github: { owner: anza-xyz, repo: mollusk, include_readmes: true, include_source_code: true }
+
+  - id: gh-litesvm
+    name: GitHub LiteSVM/litesvm
+    kind: github
+    enabled: true
+    primary_url: https://github.com/LiteSVM/litesvm
+    github: { owner: LiteSVM, repo: litesvm, include_readmes: true, include_source_code: true }
+
+  - id: gh-codama
+    name: GitHub codama-idl/codama
+    kind: github
+    enabled: true
+    primary_url: https://github.com/codama-idl/codama
+    github: { owner: codama-idl, repo: codama, include_readmes: true, include_source_code: false }
+
+  - id: gh-codama-rs
+    name: GitHub codama-idl/codama-rs
+    kind: github
+    enabled: true
+    primary_url: https://github.com/codama-idl/codama-rs
+    github: { owner: codama-idl, repo: codama-rs, include_readmes: true, include_source_code: false }
+
+  - id: gh-simd
+    name: GitHub solana-foundation/solana-improvement-documents
+    kind: github
+    enabled: true
+    primary_url: https://github.com/solana-foundation/solana-improvement-documents
+    github: { owner: solana-foundation, repo: solana-improvement-documents, include_readmes: false, include_source_code: true }
+
+  - id: gh-program-examples
+    name: GitHub solana-developers/program-examples
+    kind: github
+    enabled: true
+    primary_url: https://github.com/solana-developers/program-examples
+    github: { owner: solana-developers, repo: program-examples, include_readmes: false, include_source_code: true }
+
+  # --- SPL programs ---
+  - id: gh-spl-token
+    name: SPL Token
+    kind: github
+    enabled: true
+    primary_url: https://github.com/solana-program/token
+    github: { owner: solana-program, repo: token, include_readmes: true, include_source_code: true }
+
+  - id: gh-spl-token-2022
+    name: SPL Token 2022
+    kind: github
+    enabled: true
+    primary_url: https://github.com/solana-program/token-2022
+    github: { owner: solana-program, repo: token-2022, include_readmes: true, include_source_code: true }
+
+  - id: gh-spl-ata
+    name: SPL Associated Token Account
+    kind: github
+    enabled: true
+    primary_url: https://github.com/solana-program/associated-token-account
+    github: { owner: solana-program, repo: associated-token-account, include_readmes: true, include_source_code: true }
+
+  - id: gh-spl-address-lookup-table
+    name: Address Lookup Table
+    kind: github
+    enabled: true
+    primary_url: https://github.com/solana-program/address-lookup-table
+    github: { owner: solana-program, repo: address-lookup-table, include_readmes: true, include_source_code: true }
+
+  - id: gh-spl-loader-v4
+    name: Loader V4
+    kind: github
+    enabled: true
+    primary_url: https://github.com/solana-program/loader-v4
+    github: { owner: solana-program, repo: loader-v4, include_readmes: true, include_source_code: true }
+
+  # --- Infra / RPC providers ---
+  - id: helius-docs
+    name: Helius Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.helius.dev
+    sitemaps: [https://docs.helius.dev/sitemap.xml]
+
+  - id: quicknode-docs
+    name: QuickNode Docs
+    kind: web
+    enabled: true
+    primary_url: https://www.quicknode.com/docs/solana
+    sitemaps: [https://www.quicknode.com/docs/sitemap.xml]
+    url_include: [solana]
+
+  - id: alchemy-docs
+    name: Alchemy Docs
+    kind: web
+    enabled: true
+    primary_url: https://www.alchemy.com/docs
+    sitemaps:
+      - https://www.alchemy.com/docs/sitemap-0.xml
+      - https://www.alchemy.com/docs/sitemap-1.xml
+    url_include: [solana]
+
+  - id: chainstack-docs
+    name: Chainstack Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.chainstack.com/reference/solana-getting-started
+    sitemaps: [https://docs.chainstack.com/sitemap.xml]
+    url_include: [solana]
+
+  - id: tatum-docs
+    name: Tatum Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.tatum.io
+    sitemaps: [https://docs.tatum.io/sitemap.xml]
+    url_include: [solana]
+
+  - id: jito-docs
+    name: Jito Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.jito.wtf
+    start_urls: [https://docs.jito.wtf]
+
+  # --- Explorers / data providers ---
+  - id: solscan-docs
+    name: Solscan Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.solscan.io
+    sitemaps: [https://docs.solscan.io/sitemap-pages.xml]
+
+  - id: magic-eden-docs
+    name: Magic Eden Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.magiceden.io
+    sitemaps: [https://docs.magiceden.io/sitemap.xml]
+    url_include: [solana, /sol-, -sol-, /sol/, /mmm-sol-]
+
+  - id: birdeye-docs
+    name: Birdeye Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.birdeye.so
+    sitemaps: [https://docs.birdeye.so/sitemap.xml]
+    url_include: [solana]
+
+  - id: dexscreener-docs
+    name: DEX Screener Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.dexscreener.com
+    sitemaps: [https://docs.dexscreener.com/sitemap.xml]
+
+  - id: geckoterminal-docs
+    name: GeckoTerminal API Docs
+    kind: web
+    enabled: true
+    primary_url: https://apiguide.geckoterminal.com
+    sitemaps: [https://apiguide.geckoterminal.com/sitemap-pages.xml]
+
+  - id: coingecko-docs
+    name: CoinGecko Public API Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.coingecko.com/v3.0.1/reference/introduction
+    start_urls:
+      - https://docs.coingecko.com/v3.0.1/reference/introduction
+      - https://docs.coingecko.com/v3.0.1/
+
+  - id: bitquery-docs
+    name: Bitquery Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.bitquery.io
+    sitemaps: [https://docs.bitquery.io/sitemap.xml]
+    url_include: [solana]
+
+  - id: dune-docs
+    name: Dune Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.dune.com/data-catalog/solana
+    sitemaps: [https://docs.dune.com/sitemap.xml]
+    url_include: [solana]
+
+  - id: pumpportal-docs
+    name: PumpPortal Docs
+    kind: web
+    enabled: true
+    primary_url: https://pumpportal.fun
+    sitemaps: [https://pumpportal.fun/sitemap.xml]
+
+  # --- Wallets ---
+  - id: phantom-docs
+    name: Phantom Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.phantom.com/solana
+    sitemaps: [https://docs.phantom.com/sitemap.xml]
+    url_include: [solana]
+
+  - id: solflare-docs
+    name: Solflare Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.solflare.com/solflare
+    sitemaps: [https://docs.solflare.com/solflare/sitemap-pages.xml]
+
+  - id: squads-docs
+    name: Squads Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.squads.so/main
+    sitemaps: [https://docs.squads.so/main/sitemap-pages.xml]
+
+  # --- DEX / AMM / Perps / Lending ---
+  - id: raydium-docs
+    name: Raydium Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.raydium.io/raydium
+    sitemaps: [https://docs.raydium.io/raydium/sitemap-pages.xml]
+
+  - id: orca-docs
+    name: Orca Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.orca.so
+    sitemaps: [https://docs.orca.so/sitemap.xml]
+
+  - id: meteora-docs
+    name: Meteora Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.meteora.ag
+    sitemaps: [https://docs.meteora.ag/sitemap.xml]
+
+  - id: phoenix-docs
+    name: Phoenix Docs
+    kind: web
+    enabled: true
+    primary_url: https://ellipsis-labs.gitbook.io/phoenix-dex/tRIkEFlLUzWK9uKO3W2V
+    start_urls:
+      - https://ellipsis-labs.gitbook.io/phoenix-dex/tRIkEFlLUzWK9uKO3W2V
+
+  - id: goosefx-docs
+    name: GooseFX Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.goosefx.io
+    sitemaps: [https://docs.goosefx.io/sitemap.xml]
+
+  - id: fluxbeam-docs
+    name: FluxBeam Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.fluxbeam.xyz/
+    sitemaps: [https://docs.fluxbeam.xyz/sitemap.xml]
+
+  - id: lifinity-docs
+    name: Lifinity Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.lifinity.io
+    sitemaps: [https://docs.lifinity.io/sitemap.xml]
+
+  - id: hxro-docs
+    name: Hxro Network Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.hxro.network
+    sitemaps: [https://docs.hxro.network/sitemap-pages.xml]
+
+  - id: flash-trade-docs
+    name: Flash.Trade Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.flash.trade
+    sitemaps: [https://docs.flash.trade/flash-trade/sitemap.xml]
+
+  - id: zeta-docs
+    name: Zeta Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.zeta.markets/
+    sitemaps: [https://docs.zeta.markets/sitemap.xml]
+
+  - id: drift-docs
+    name: Drift Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.drift.trade
+    start_urls: [https://docs.drift.trade]
+
+  - id: drift-v2-teacher
+    name: Drift v2 API Docs
+    kind: web
+    enabled: true
+    primary_url: https://drift-labs.github.io/v2-teacher
+    ingest_urls: [https://drift-labs.github.io/v2-teacher]
+
+  - id: drift-data-api
+    name: Drift Data API (OpenAPI)
+    kind: openapi
+    enabled: true
+    primary_url: https://data.api.drift.trade/playground
+    spec_url: https://data.api.drift.trade/playground/json
+
+  - id: gh-drift-protocol-v2
+    name: GitHub drift-labs/protocol-v2
+    kind: github
+    enabled: true
+    primary_url: https://github.com/drift-labs/protocol-v2
+    github: { owner: drift-labs, repo: protocol-v2, include_readmes: true, include_source_code: true }
+
+  - id: kamino-docs
+    name: Kamino Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.kamino.finance
+    sitemaps: [https://docs.kamino.finance/sitemap.xml]
+
+  - id: solend-docs
+    name: Solend Docs
+    kind: web
+    enabled: true
+    primary_url: https://dev.solend.fi
+    start_urls:
+      - https://dev.solend.fi
+      - https://dev.solend.fi/docs/intro/
+
+  - id: marginfi-docs
+    name: marginfi Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.marginfi.com
+    start_urls: [https://docs.marginfi.com]
+
+  - id: marinade-docs
+    name: Marinade Docs
+    kind: web
+    enabled: true
+    primary_url: https://docs.marinade.finance
+    sitemaps: [https://docs.marinade.finance/sitemap.xml]
+
+  - id: blazestake-docs
+    name: BlazeStake Docs
+    kind: web
+    enabled: true
+    primary_url: https://stake-docs.solblaze.org
+    sitemaps: [https://stake-docs.solblaze.org/sitemap.xml]
+
+  - id: sanctum-infinity-docs
+    name: Sanctum > Infinity Docs
+    kind: web
+    enabled: true
+    primary_url: https://learn.sanctum.so/docs
+    sitemaps: [https://learn.sanctum.so/docs/sitemap-pages.xml]
+
+  # --- Community Q&A (LARGE, gated off by default) ---
+  - id: solana-stackexchange
+    name: Solana Stackexchange
+    kind: web
+    enabled: false  # huge corpus — enable when chunking + rate-limit strategy ready
+    primary_url: https://solana.stackexchange.com
+    start_urls: [https://solana.stackexchange.com]

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,5 +1,7 @@
-import { logInitialization, logToolCallRequest, logToolCallResponse } from "./services/neon/analytics";
+import * as neonAnalytics from "./services/neon/analytics";
+import * as databricksAnalytics from "./services/databricks/analytics";
 import { logInkeepToolResponse } from "./services/inkeep/analytics";
+import { useDatabricks } from "./flags";
 
 export type EventType = "message_received" | "message_response" | "tool_call" | "tool_response";
 
@@ -24,8 +26,20 @@ export type AnalyticsEvent =
       timestamp?: string;
     };
 
+type AnalyticsSink = {
+  logInitialization: typeof neonAnalytics.logInitialization;
+  logToolCallRequest: typeof neonAnalytics.logToolCallRequest;
+  logToolCallResponse: typeof neonAnalytics.logToolCallResponse;
+};
+
+function analyticsSink(): AnalyticsSink {
+  return useDatabricks() ? databricksAnalytics : neonAnalytics;
+}
+
 export async function logAnalytics(event: AnalyticsEvent) {
   try {
+    const sink = analyticsSink();
+
     if (event.event_type === "message_received") {
       const { body } = event.details;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,7 +54,7 @@ export async function logAnalytics(event: AnalyticsEvent) {
       switch (parsedBody.method) {
         case "initialize": {
           const { protocolVersion, capabilities, clientInfo } = parsedBody.params || {};
-          await logInitialization({
+          await sink.logInitialization({
             protocolVersion,
             capabilities,
             clientName: clientInfo?.name || "",
@@ -52,7 +66,7 @@ export async function logAnalytics(event: AnalyticsEvent) {
 
         case "tools/call": {
           const { name, arguments: toolArgs } = parsedBody.params || {};
-          await logToolCallRequest({
+          await sink.logToolCallRequest({
             toolName: name,
             requestId: event.request_id ?? null,
             sessionId: event.session_id ?? null,
@@ -68,8 +82,11 @@ export async function logAnalytics(event: AnalyticsEvent) {
       }
     } else if (event.event_type === "message_response") {
       const { tool, req, res } = event.details;
-      logToolCallResponse({ tool, req, res, rawBody: event.details });
-      await logInkeepToolResponse({ tool, req, res });
+      sink.logToolCallResponse({ tool, req, res, rawBody: event.details });
+
+      if (!useDatabricks()) {
+        await logInkeepToolResponse({ tool, req, res });
+      }
     }
   } catch (err) {
     console.error("[logAnalytics] Unexpected error:", err);

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -1,0 +1,3 @@
+export function useDatabricks(): boolean {
+  return process.env.USE_DATABRICKS === "1";
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -69,6 +69,7 @@ export function createMcp() {
     {
       basePath: "",
       redisUrl: process.env.REDIS_URL,
+      disableSse: !process.env.REDIS_URL,
       maxDuration: 120,
       verboseLogs: true,
     },

--- a/lib/services/databricks/analytics.ts
+++ b/lib/services/databricks/analytics.ts
@@ -1,0 +1,167 @@
+import * as dotenv from "dotenv";
+import { dbxFetch, isDatabricksConfigured } from "./client.js";
+
+dotenv.config();
+
+// Schema hosting the analytics tables. Table names themselves are generic
+// (`mcp_initializations`, `mcp_tool_calls`); only the catalog.schema prefix
+// needs to be set per deployment.
+function analyticsSchema(): string | null {
+  const schema = process.env.DATABRICKS_ANALYTICS_SCHEMA;
+  return schema ? schema.replace(/\.$/, "") : null;
+}
+
+type SqlParamType = "STRING" | "TIMESTAMP";
+
+interface SqlParam {
+  name: string;
+  value: string | null;
+  type: SqlParamType;
+}
+
+interface SqlExecuteRequest {
+  warehouse_id: string;
+  statement: string;
+  parameters: SqlParam[];
+  wait_timeout: string;
+}
+
+function resolveWarehouse(): string | null {
+  if (!isDatabricksConfigured()) return null;
+  const warehouseId = process.env.DATABRICKS_WAREHOUSE_ID;
+  if (!warehouseId) return null;
+  return warehouseId;
+}
+
+async function executeInsert(statement: string, parameters: SqlParam[]): Promise<void> {
+  const warehouseId = resolveWarehouse();
+  if (!warehouseId) {
+    console.warn("[analytics] Databricks env not set — analytics disabled");
+    return;
+  }
+
+  const body: SqlExecuteRequest = {
+    warehouse_id: warehouseId,
+    statement,
+    parameters,
+    wait_timeout: "30s",
+  };
+
+  const res = await dbxFetch<{
+    status?: { state?: string; error?: { message?: string } };
+    statement_id?: string;
+  }>("/api/2.0/sql/statements", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+  const state = res.status?.state;
+  if (state !== "SUCCEEDED") {
+    const err = res.status?.error?.message ?? "(no error message)";
+    throw new Error(`SQL statement ${res.statement_id ?? "?"} ended in state ${state ?? "?"}: ${err}`);
+  }
+}
+
+function stringify(value: unknown): string {
+  return JSON.stringify(value ?? null);
+}
+
+export async function logInitialization(params: {
+  protocolVersion: string;
+  capabilities: unknown;
+  clientName: string;
+  clientVersion: string;
+  rawBody: unknown;
+}): Promise<void> {
+  const schema = analyticsSchema();
+  if (!schema) {
+    console.warn("[analytics] DATABRICKS_ANALYTICS_SCHEMA not set — analytics disabled");
+    return;
+  }
+
+  const { protocolVersion, capabilities, clientName, clientVersion, rawBody } = params;
+
+  const statement = `
+    INSERT INTO ${schema}.mcp_initializations
+      (timestamp, method, protocol_version, capabilities, client_name, client_version, raw_body)
+    VALUES
+      (CAST(:timestamp AS TIMESTAMP), :method, :protocolVersion, :capabilities, :clientName, :clientVersion, :rawBody)
+  `;
+
+  const parameters: SqlParam[] = [
+    { name: "timestamp", value: new Date().toISOString(), type: "STRING" },
+    { name: "method", value: "initialize", type: "STRING" },
+    { name: "protocolVersion", value: protocolVersion, type: "STRING" },
+    { name: "capabilities", value: stringify(capabilities), type: "STRING" },
+    { name: "clientName", value: clientName, type: "STRING" },
+    { name: "clientVersion", value: clientVersion, type: "STRING" },
+    { name: "rawBody", value: stringify(rawBody), type: "STRING" },
+  ];
+
+  await executeInsert(statement, parameters);
+}
+
+export async function logToolCallRequest(params: {
+  toolName: string;
+  requestId: string | null;
+  sessionId: string | null;
+  toolArgs: unknown;
+  rawBody: unknown;
+}): Promise<void> {
+  const schema = analyticsSchema();
+  if (!schema) {
+    console.warn("[analytics] DATABRICKS_ANALYTICS_SCHEMA not set — analytics disabled");
+    return;
+  }
+
+  const { toolName, requestId, sessionId, toolArgs, rawBody } = params;
+
+  const statement = `
+    INSERT INTO ${schema}.mcp_tool_calls
+      (timestamp, row_type, tool_name, request_id, session_id, arguments, raw_body)
+    VALUES
+      (CAST(:timestamp AS TIMESTAMP), :rowType, :toolName, :requestId, :sessionId, :arguments, :rawBody)
+  `;
+
+  const parameters: SqlParam[] = [
+    { name: "timestamp", value: new Date().toISOString(), type: "STRING" },
+    { name: "rowType", value: "request", type: "STRING" },
+    { name: "toolName", value: toolName, type: "STRING" },
+    { name: "requestId", value: requestId, type: "STRING" },
+    { name: "sessionId", value: sessionId, type: "STRING" },
+    { name: "arguments", value: stringify(toolArgs), type: "STRING" },
+    { name: "rawBody", value: stringify(rawBody), type: "STRING" },
+  ];
+
+  await executeInsert(statement, parameters);
+}
+
+export function logToolCallResponse(params: { tool: string; req: string; res: string; rawBody: unknown }): void {
+  const schema = analyticsSchema();
+  if (!schema) {
+    console.warn("[analytics] DATABRICKS_ANALYTICS_SCHEMA not set — analytics disabled");
+    return;
+  }
+
+  const { tool, req, res, rawBody } = params;
+
+  const statement = `
+    INSERT INTO ${schema}.mcp_tool_calls
+      (timestamp, row_type, tool_name, arguments, response_text, raw_body)
+    VALUES
+      (CAST(:timestamp AS TIMESTAMP), :rowType, :toolName, :arguments, :responseText, :rawBody)
+  `;
+
+  const parameters: SqlParam[] = [
+    { name: "timestamp", value: new Date().toISOString(), type: "STRING" },
+    { name: "rowType", value: "response", type: "STRING" },
+    { name: "toolName", value: tool, type: "STRING" },
+    { name: "arguments", value: stringify(req), type: "STRING" },
+    { name: "responseText", value: res, type: "STRING" },
+    { name: "rawBody", value: stringify(rawBody), type: "STRING" },
+  ];
+
+  executeInsert(statement, parameters).catch((err: unknown) => {
+    console.error("[logToolCallResponse] Error inserting tool response:", err);
+  });
+}

--- a/lib/services/databricks/client.ts
+++ b/lib/services/databricks/client.ts
@@ -1,0 +1,136 @@
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+export class DatabricksError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly path: string,
+    bodySnippet: string,
+  ) {
+    super(`Databricks ${status} on ${path}: ${bodySnippet}`);
+    this.name = "DatabricksError";
+  }
+}
+
+const MAX_ATTEMPTS = 3;
+const BACKOFF_MS = [250, 1000, 4000];
+const MAX_BODY_SNIPPET = 500;
+const OAUTH_REFRESH_MARGIN_MS = 60_000;
+
+type AuthMode =
+  | { kind: "pat"; host: string; token: string }
+  | { kind: "oauth"; host: string; clientId: string; clientSecret: string };
+
+interface CachedOauthToken {
+  token: string;
+  expiresAt: number;
+}
+
+let cachedOauthToken: CachedOauthToken | null = null;
+
+function resolveHost(): string | null {
+  const raw = process.env.DATABRICKS_HOST;
+  if (!raw) return null;
+  const trimmed = raw.replace(/\/$/, "");
+  return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+}
+
+function resolveAuthMode(): AuthMode | null {
+  const host = resolveHost();
+  if (!host) return null;
+
+  const token = process.env.DATABRICKS_TOKEN;
+  if (token) return { kind: "pat", host, token };
+
+  const clientId = process.env.DATABRICKS_CLIENT_ID;
+  const clientSecret = process.env.DATABRICKS_CLIENT_SECRET;
+  if (clientId && clientSecret) return { kind: "oauth", host, clientId, clientSecret };
+
+  return null;
+}
+
+export function isDatabricksConfigured(): boolean {
+  return resolveAuthMode() !== null;
+}
+
+async function fetchOauthToken(mode: Extract<AuthMode, { kind: "oauth" }>): Promise<string> {
+  if (cachedOauthToken && cachedOauthToken.expiresAt - OAUTH_REFRESH_MARGIN_MS > Date.now()) {
+    return cachedOauthToken.token;
+  }
+
+  const credentials = Buffer.from(`${mode.clientId}:${mode.clientSecret}`).toString("base64");
+  const res = await fetch(`${mode.host}/oidc/v1/token`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${credentials}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: "grant_type=client_credentials&scope=all-apis",
+  });
+
+  if (!res.ok) {
+    const snippet = (await res.text()).slice(0, MAX_BODY_SNIPPET);
+    throw new DatabricksError(res.status, "/oidc/v1/token", snippet);
+  }
+
+  const json = (await res.json()) as { access_token: string; expires_in: number };
+  cachedOauthToken = {
+    token: json.access_token,
+    expiresAt: Date.now() + json.expires_in * 1000,
+  };
+  return json.access_token;
+}
+
+async function resolveBearerToken(mode: AuthMode): Promise<string> {
+  return mode.kind === "pat" ? mode.token : fetchOauthToken(mode);
+}
+
+export async function dbxFetch<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const mode = resolveAuthMode();
+  if (!mode) {
+    throw new Error(
+      "Databricks client not configured: set DATABRICKS_HOST and either DATABRICKS_TOKEN or DATABRICKS_CLIENT_ID+DATABRICKS_CLIENT_SECRET",
+    );
+  }
+
+  const bearer = await resolveBearerToken(mode);
+  const url = `${mode.host}${path.startsWith("/") ? path : `/${path}`}`;
+  const headers = new Headers(init.headers);
+  headers.set("Authorization", `Bearer ${bearer}`);
+  if (!headers.has("Content-Type") && init.body) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(url, { ...init, headers });
+      if (res.ok) {
+        return (await res.json()) as T;
+      }
+      const bodyText = (await res.text()).slice(0, MAX_BODY_SNIPPET);
+      if ((res.status === 429 || res.status >= 500) && attempt < MAX_ATTEMPTS - 1) {
+        await sleep(BACKOFF_MS[attempt]);
+        continue;
+      }
+      throw new DatabricksError(res.status, path, bodyText);
+    } catch (err) {
+      if (err instanceof DatabricksError) throw err;
+      lastError = err;
+      if (attempt < MAX_ATTEMPTS - 1) {
+        await sleep(BACKOFF_MS[attempt]);
+        continue;
+      }
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`Databricks request to ${path} failed after ${MAX_ATTEMPTS} attempts`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/lib/services/databricks/vectorSearch.ts
+++ b/lib/services/databricks/vectorSearch.ts
@@ -1,0 +1,87 @@
+import * as dotenv from "dotenv";
+import { dbxFetch, isDatabricksConfigured } from "./client.js";
+
+dotenv.config();
+
+export interface DocChunk {
+  id: string;
+  url: string | null;
+  title: string | null;
+  sourceId: string | null;
+  content: string | null;
+  score: number;
+}
+
+interface VsQueryResponse {
+  manifest?: { columns?: { name: string }[] };
+  result?: { data_array?: unknown[][] };
+}
+
+// `score` is always returned by Databricks Vector Search query responses, but
+// only source-table columns belong in `columns`; the score arrives as a
+// synthetic trailing field in each row. We still request the metadata columns
+// we want materialized in the result.
+const REQUESTED_COLUMNS = ["id", "url", "title", "source_id", "content"] as const;
+
+const OVERSAMPLE_MULTIPLIER = 3;
+
+export async function searchDocs(query: string, k = 8): Promise<DocChunk[]> {
+  const index = process.env.DATABRICKS_VS_INDEX;
+  if (!isDatabricksConfigured() || !index) {
+    console.warn("[vectorSearch] DATABRICKS_VS_INDEX (or host/token) not set — retrieval disabled");
+    return [];
+  }
+
+  const body = {
+    query_text: query,
+    columns: [...REQUESTED_COLUMNS],
+    num_results: k * OVERSAMPLE_MULTIPLIER,
+  };
+
+  const res = await dbxFetch<VsQueryResponse>(`/api/2.0/vector-search/indexes/${index}/query`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+  const columns = res.manifest?.columns?.map(c => c.name) ?? [];
+  const rows = res.result?.data_array ?? [];
+  const chunks = rows.map(row => rowToChunk(columns, row));
+
+  // Sort score-descending before dedupe so the highest-scored chunk per URL
+  // is kept, independent of any ordering guarantee from the Databricks API.
+  chunks.sort((a, b) => b.score - a.score);
+  return dedupeByUrl(chunks).slice(0, k);
+}
+
+function dedupeByUrl(chunks: DocChunk[]): DocChunk[] {
+  const seen = new Set<string>();
+  const out: DocChunk[] = [];
+  for (const chunk of chunks) {
+    const key = chunk.url ?? chunk.id;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(chunk);
+  }
+  return out;
+}
+
+function rowToChunk(columns: string[], row: unknown[]): DocChunk {
+  const get = (name: string): unknown => {
+    const idx = columns.indexOf(name);
+    return idx === -1 ? null : row[idx];
+  };
+
+  return {
+    id: String(get("id") ?? ""),
+    url: asNullableString(get("url")),
+    title: asNullableString(get("title")),
+    sourceId: asNullableString(get("source_id")),
+    content: asNullableString(get("content")),
+    score: Number(get("score") ?? 0),
+  };
+}
+
+function asNullableString(v: unknown): string | null {
+  if (v === null || v === undefined) return null;
+  return String(v);
+}

--- a/lib/tools/formatChunks.ts
+++ b/lib/tools/formatChunks.ts
@@ -1,0 +1,31 @@
+import type { DocChunk } from "../services/databricks/vectorSearch.js";
+
+export function formatChunksAsMarkdown(query: string, chunks: DocChunk[]): string {
+  if (chunks.length === 0) {
+    return `No relevant documentation found for: "${query}".`;
+  }
+
+  const sections = chunks.map((chunk, idx) => renderChunk(idx + 1, chunk));
+  return `Top ${chunks.length} matches for "${query}":\n\n${sections.join("\n\n---\n\n")}`;
+}
+
+function renderChunk(position: number, chunk: DocChunk): string {
+  const heading = renderHeading(position, chunk);
+  const meta = renderMeta(chunk);
+  const body = (chunk.content ?? "").trim();
+  return [heading, meta, body].filter(Boolean).join("\n\n");
+}
+
+function renderHeading(position: number, chunk: DocChunk): string {
+  if (chunk.title && chunk.url) return `### ${position}. [${chunk.title}](${chunk.url})`;
+  if (chunk.title) return `### ${position}. ${chunk.title}`;
+  if (chunk.url) return `### ${position}. ${chunk.url}`;
+  return `### ${position}.`;
+}
+
+function renderMeta(chunk: DocChunk): string {
+  const parts: string[] = [];
+  if (chunk.sourceId) parts.push(`source: ${chunk.sourceId}`);
+  parts.push(`score: ${chunk.score.toFixed(3)}`);
+  return `_${parts.join(" · ")}_`;
+}

--- a/lib/tools/generalSolanaTools.ts
+++ b/lib/tools/generalSolanaTools.ts
@@ -1,7 +1,40 @@
 import { z } from "zod";
 import { generateText, LanguageModel } from "ai";
 import { logAnalytics } from "../analytics";
+import { useDatabricks } from "../flags";
+import { searchDocs } from "../services/databricks/vectorSearch.js";
+import { formatChunksAsMarkdown } from "./formatChunks.js";
 import type { SolanaTool } from "./types";
+
+async function answerViaDatabricks(tool: "Solana_Expert__Ask_For_Help" | "Solana_Documentation_Search", query: string) {
+  const chunks = await searchDocs(query, 8);
+  const text = formatChunksAsMarkdown(query, chunks);
+
+  await logAnalytics({
+    event_type: "message_response",
+    details: { tool, req: query, res: text },
+  });
+
+  return { content: [{ type: "text", text }] };
+}
+
+async function answerViaModel(
+  model: LanguageModel,
+  tool: "Solana_Expert__Ask_For_Help" | "Solana_Documentation_Search",
+  query: string,
+) {
+  const { text } = await generateText({
+    model,
+    messages: [{ role: "user", content: query }],
+  });
+
+  await logAnalytics({
+    event_type: "message_response",
+    details: { tool, req: query, res: text },
+  });
+
+  return { content: [{ type: "text", text }] };
+}
 
 export function createSolanaTools(model: LanguageModel | null): SolanaTool[] {
   return [
@@ -17,6 +50,10 @@ export function createSolanaTools(model: LanguageModel | null): SolanaTool[] {
       },
 
       func: async ({ question }: { question: string }) => {
+        if (useDatabricks()) {
+          return answerViaDatabricks("Solana_Expert__Ask_For_Help", question);
+        }
+
         if (!model) {
           return {
             content: [{ type: "text", text: "Error: No AI provider is configured for this tool." }],
@@ -24,21 +61,7 @@ export function createSolanaTools(model: LanguageModel | null): SolanaTool[] {
           };
         }
 
-        const { text } = await generateText({
-          model,
-          messages: [{ role: "user", content: question }],
-        });
-
-        await logAnalytics({
-          event_type: "message_response",
-          details: {
-            tool: "Solana_Expert__Ask_For_Help",
-            req: question,
-            res: text,
-          },
-        });
-
-        return { content: [{ type: "text", text }] };
+        return answerViaModel(model, "Solana_Expert__Ask_For_Help", question);
       },
     },
 
@@ -52,6 +75,10 @@ export function createSolanaTools(model: LanguageModel | null): SolanaTool[] {
       },
 
       func: async ({ query }: { query: string }) => {
+        if (useDatabricks()) {
+          return answerViaDatabricks("Solana_Documentation_Search", query);
+        }
+
         if (!model) {
           return {
             content: [{ type: "text", text: "Error: No AI provider is configured for this tool." }],
@@ -59,21 +86,7 @@ export function createSolanaTools(model: LanguageModel | null): SolanaTool[] {
           };
         }
 
-        const { text } = await generateText({
-          model,
-          messages: [{ role: "user", content: query }],
-        });
-
-        await logAnalytics({
-          event_type: "message_response",
-          details: {
-            tool: "Solana_Documentation_Search",
-            req: query,
-            res: text,
-          },
-        });
-
-        return { content: [{ type: "text", text }] };
+        return answerViaModel(model, "Solana_Documentation_Search", query);
       },
     },
   ];

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "start": "vercel dev",
     "dev:local": "vercel dev --local",
+    "build": "tsup",
+    "start:app": "node dist/start.js",
     "test": "pnpm test:integration",
     "test:integration": "vitest run tests/integration.test.ts tests/unit/",
     "test:e2e": "vitest run tests/e2e.test.ts",
@@ -58,6 +60,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@solana/prettier-config-solana": "^0.0.6",
+    "@types/express": "^5.0.6",
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^4.1.3",
     "eslint": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@solana/prettier-config-solana':
         specifier: ^0.0.6
         version: 0.0.6(prettier@3.8.3)
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -1956,6 +1959,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1971,6 +1977,15 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1982,6 +1997,18 @@ packages:
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/qs@6.15.0':
+    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
@@ -5554,6 +5581,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 25.6.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -5569,6 +5601,21 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 25.6.0
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/node@12.20.55': {}
@@ -5580,6 +5627,19 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/qs@6.15.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 25.6.0
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 25.6.0
 
   '@types/uuid@10.0.0': {}
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -89,6 +89,7 @@ describe("createMcp", () => {
       {
         basePath: string;
         redisUrl?: string;
+        disableSse: boolean;
         maxDuration: number;
         verboseLogs: boolean;
       },
@@ -99,9 +100,30 @@ describe("createMcp", () => {
     expect(config).toEqual({
       basePath: "",
       redisUrl: "redis://127.0.0.1:6379",
+      disableSse: false,
       maxDuration: 120,
       verboseLogs: true,
     });
+  });
+
+  it("disables SSE when no REDIS_URL is set", () => {
+    const previousRedisUrl = process.env.REDIS_URL;
+    delete process.env.REDIS_URL;
+    createMcpHandlerMock.mockReturnValue(vi.fn());
+
+    try {
+      createMcp();
+    } finally {
+      if (previousRedisUrl !== undefined) process.env.REDIS_URL = previousRedisUrl;
+    }
+
+    const [, , config] = createMcpHandlerMock.mock.calls[0] as [
+      unknown,
+      unknown,
+      { disableSse: boolean; redisUrl?: string },
+    ];
+    expect(config.disableSse).toBe(true);
+    expect(config.redisUrl).toBeUndefined();
   });
 
   it("registers tools, resources, and startup prompt", async () => {

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -1,17 +1,33 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { logInitializationMock, logToolCallRequestMock, logToolCallResponseMock, logInkeepToolResponseMock } =
-  vi.hoisted(() => ({
-    logInitializationMock: vi.fn(),
-    logToolCallRequestMock: vi.fn(),
-    logToolCallResponseMock: vi.fn(),
-    logInkeepToolResponseMock: vi.fn(),
-  }));
+const {
+  logInitializationMock,
+  logToolCallRequestMock,
+  logToolCallResponseMock,
+  logInkeepToolResponseMock,
+  dbxLogInitializationMock,
+  dbxLogToolCallRequestMock,
+  dbxLogToolCallResponseMock,
+} = vi.hoisted(() => ({
+  logInitializationMock: vi.fn(),
+  logToolCallRequestMock: vi.fn(),
+  logToolCallResponseMock: vi.fn(),
+  logInkeepToolResponseMock: vi.fn(),
+  dbxLogInitializationMock: vi.fn(),
+  dbxLogToolCallRequestMock: vi.fn(),
+  dbxLogToolCallResponseMock: vi.fn(),
+}));
 
 vi.mock("../../lib/services/neon/analytics", () => ({
   logInitialization: logInitializationMock,
   logToolCallRequest: logToolCallRequestMock,
   logToolCallResponse: logToolCallResponseMock,
+}));
+
+vi.mock("../../lib/services/databricks/analytics", () => ({
+  logInitialization: dbxLogInitializationMock,
+  logToolCallRequest: dbxLogToolCallRequestMock,
+  logToolCallResponse: dbxLogToolCallResponseMock,
 }));
 
 vi.mock("../../lib/services/inkeep/analytics", () => ({
@@ -27,6 +43,14 @@ describe("logAnalytics", () => {
     logToolCallRequestMock.mockResolvedValue(undefined);
     logToolCallResponseMock.mockReturnValue(undefined);
     logInkeepToolResponseMock.mockResolvedValue(undefined);
+    dbxLogInitializationMock.mockResolvedValue(undefined);
+    dbxLogToolCallRequestMock.mockResolvedValue(undefined);
+    dbxLogToolCallResponseMock.mockReturnValue(undefined);
+    delete process.env.USE_DATABRICKS;
+  });
+
+  afterEach(() => {
+    delete process.env.USE_DATABRICKS;
   });
 
   it("routes initialize to logInitialization with parsed params", async () => {
@@ -51,6 +75,7 @@ describe("logAnalytics", () => {
       clientVersion: "1.2.3",
       rawBody: expect.objectContaining({ method: "initialize" }),
     });
+    expect(dbxLogInitializationMock).not.toHaveBeenCalled();
   });
 
   it("routes tools/call to logToolCallRequest with request metadata", async () => {
@@ -76,6 +101,7 @@ describe("logAnalytics", () => {
       toolArgs: { query: "accounts" },
       rawBody: expect.objectContaining({ method: "tools/call" }),
     });
+    expect(dbxLogToolCallRequestMock).not.toHaveBeenCalled();
   });
 
   it("routes message_response to logToolCallResponse and logInkeepToolResponse", async () => {
@@ -99,6 +125,7 @@ describe("logAnalytics", () => {
       req: "find docs",
       res: '{"content":[]}',
     });
+    expect(dbxLogToolCallResponseMock).not.toHaveBeenCalled();
   });
 
   it("rejects malformed JSON without calling any service", async () => {
@@ -127,5 +154,58 @@ describe("logAnalytics", () => {
     expect(logToolCallRequestMock).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalledWith("[logAnalytics] Skipping method:", "unknown/method");
     warnSpy.mockRestore();
+  });
+
+  describe("USE_DATABRICKS=1", () => {
+    beforeEach(() => {
+      process.env.USE_DATABRICKS = "1";
+    });
+
+    it("routes initialize to databricks sink instead of neon", async () => {
+      await logAnalytics({
+        event_type: "message_received",
+        details: {
+          body: JSON.stringify({
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-03-26",
+              capabilities: {},
+              clientInfo: { name: "claude", version: "4.7" },
+            },
+          }),
+        },
+      });
+
+      expect(dbxLogInitializationMock).toHaveBeenCalledTimes(1);
+      expect(logInitializationMock).not.toHaveBeenCalled();
+    });
+
+    it("routes tools/call to databricks sink instead of neon", async () => {
+      await logAnalytics({
+        event_type: "message_received",
+        request_id: "r1",
+        session_id: "s1",
+        details: {
+          body: JSON.stringify({
+            method: "tools/call",
+            params: { name: "Solana_Documentation_Search", arguments: { query: "pda" } },
+          }),
+        },
+      });
+
+      expect(dbxLogToolCallRequestMock).toHaveBeenCalledTimes(1);
+      expect(logToolCallRequestMock).not.toHaveBeenCalled();
+    });
+
+    it("sends message_response to databricks sink and skips inkeep analytics", async () => {
+      await logAnalytics({
+        event_type: "message_response",
+        details: { tool: "Solana_Documentation_Search", req: "q", res: "chunks..." },
+      });
+
+      expect(dbxLogToolCallResponseMock).toHaveBeenCalledTimes(1);
+      expect(logToolCallResponseMock).not.toHaveBeenCalled();
+      expect(logInkeepToolResponseMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/unit/databricks.analytics.test.ts
+++ b/tests/unit/databricks.analytics.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const HOST = "https://dbc-test.cloud.databricks.com";
+const TOKEN = "dapi-test-token";
+const WAREHOUSE = "wh-test-123";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+interface RecordedRequest {
+  url: string;
+  body: {
+    warehouse_id: string;
+    statement: string;
+    parameters: { name: string; value: string | null; type: string }[];
+    wait_timeout: string;
+  };
+}
+
+function recordedRequest(call: [string, RequestInit]): RecordedRequest {
+  const [url, init] = call;
+  return { url, body: JSON.parse(init.body as string) };
+}
+
+function findParam(req: RecordedRequest, name: string): string | null | undefined {
+  return req.body.parameters.find(p => p.name === name)?.value;
+}
+
+describe("databricks analytics service", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockResolvedValue(jsonResponse({ status: { state: "SUCCEEDED" } }));
+    process.env.DATABRICKS_HOST = HOST;
+    process.env.DATABRICKS_TOKEN = TOKEN;
+    process.env.DATABRICKS_WAREHOUSE_ID = WAREHOUSE;
+    process.env.DATABRICKS_ANALYTICS_SCHEMA = "test_catalog.test_schema";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.DATABRICKS_HOST;
+    delete process.env.DATABRICKS_TOKEN;
+    delete process.env.DATABRICKS_WAREHOUSE_ID;
+    delete process.env.DATABRICKS_ANALYTICS_SCHEMA;
+  });
+
+  describe("logInitialization", () => {
+    it("skips and warns when warehouse id missing", async () => {
+      delete process.env.DATABRICKS_WAREHOUSE_ID;
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      const { logInitialization } = await import("../../lib/services/databricks/analytics.js");
+
+      await logInitialization({
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientName: "codex",
+        clientVersion: "1.0.0",
+        rawBody: {},
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith("[analytics] Databricks env not set — analytics disabled");
+      warnSpy.mockRestore();
+    });
+
+    it("skips and warns when host/token missing", async () => {
+      delete process.env.DATABRICKS_TOKEN;
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      const { logInitialization } = await import("../../lib/services/databricks/analytics.js");
+
+      await logInitialization({
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientName: "codex",
+        clientVersion: "1.0.0",
+        rawBody: {},
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it("POSTs SQL statement with correct parameters", async () => {
+      const { logInitialization } = await import("../../lib/services/databricks/analytics.js");
+
+      await logInitialization({
+        protocolVersion: "2025-03-26",
+        capabilities: { roots: { listChanged: true } },
+        clientName: "codex",
+        clientVersion: "1.2.3",
+        rawBody: { method: "initialize" },
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const req = recordedRequest(fetchMock.mock.calls[0] as [string, RequestInit]);
+      expect(req.url).toBe(`${HOST}/api/2.0/sql/statements`);
+      expect(req.body.warehouse_id).toBe(WAREHOUSE);
+      expect(req.body.statement).toContain("mcp_initializations");
+
+      expect(findParam(req, "method")).toBe("initialize");
+      expect(findParam(req, "protocolVersion")).toBe("2025-03-26");
+      expect(findParam(req, "clientName")).toBe("codex");
+      expect(findParam(req, "clientVersion")).toBe("1.2.3");
+      expect(findParam(req, "capabilities")).toBe(JSON.stringify({ roots: { listChanged: true } }));
+      expect(findParam(req, "rawBody")).toBe(JSON.stringify({ method: "initialize" }));
+    });
+  });
+
+  describe("logToolCallRequest", () => {
+    it("skips when env missing", async () => {
+      delete process.env.DATABRICKS_WAREHOUSE_ID;
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      const { logToolCallRequest } = await import("../../lib/services/databricks/analytics.js");
+
+      await logToolCallRequest({
+        toolName: "Solana_Documentation_Search",
+        requestId: "req-1",
+        sessionId: "sess-1",
+        toolArgs: { query: "accounts" },
+        rawBody: {},
+      });
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it("POSTs a request row with tool metadata", async () => {
+      const { logToolCallRequest } = await import("../../lib/services/databricks/analytics.js");
+
+      await logToolCallRequest({
+        toolName: "Solana_Documentation_Search",
+        requestId: "req-123",
+        sessionId: "session-456",
+        toolArgs: { query: "accounts" },
+        rawBody: { method: "tools/call" },
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const req = recordedRequest(fetchMock.mock.calls[0] as [string, RequestInit]);
+      expect(req.body.statement).toContain("mcp_tool_calls");
+      expect(findParam(req, "rowType")).toBe("request");
+      expect(findParam(req, "toolName")).toBe("Solana_Documentation_Search");
+      expect(findParam(req, "requestId")).toBe("req-123");
+      expect(findParam(req, "sessionId")).toBe("session-456");
+      expect(findParam(req, "arguments")).toBe(JSON.stringify({ query: "accounts" }));
+    });
+
+    it("allows null requestId and sessionId", async () => {
+      const { logToolCallRequest } = await import("../../lib/services/databricks/analytics.js");
+
+      await logToolCallRequest({
+        toolName: "Solana_Expert__Ask_For_Help",
+        requestId: null,
+        sessionId: null,
+        toolArgs: {},
+        rawBody: {},
+      });
+
+      const req = recordedRequest(fetchMock.mock.calls[0] as [string, RequestInit]);
+      expect(findParam(req, "requestId")).toBeNull();
+      expect(findParam(req, "sessionId")).toBeNull();
+    });
+  });
+
+  describe("logToolCallResponse", () => {
+    it("skips fire-and-forget when env missing", async () => {
+      delete process.env.DATABRICKS_WAREHOUSE_ID;
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      const { logToolCallResponse } = await import("../../lib/services/databricks/analytics.js");
+
+      logToolCallResponse({
+        tool: "Solana_Documentation_Search",
+        req: "find docs",
+        res: '{"content":[]}',
+        rawBody: {},
+      });
+
+      await new Promise(resolve => process.nextTick(resolve));
+      expect(fetchMock).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it("fires a response-row insert without awaiting", async () => {
+      const { logToolCallResponse } = await import("../../lib/services/databricks/analytics.js");
+
+      logToolCallResponse({
+        tool: "Solana_Documentation_Search",
+        req: "find docs",
+        res: '{"content":[]}',
+        rawBody: { tool: "Solana_Documentation_Search" },
+      });
+
+      await new Promise(resolve => process.nextTick(resolve));
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const req = recordedRequest(fetchMock.mock.calls[0] as [string, RequestInit]);
+      expect(req.body.statement).toContain("mcp_tool_calls");
+      expect(findParam(req, "rowType")).toBe("response");
+      expect(findParam(req, "toolName")).toBe("Solana_Documentation_Search");
+      expect(findParam(req, "responseText")).toBe('{"content":[]}');
+      expect(findParam(req, "arguments")).toBe(JSON.stringify("find docs"));
+    });
+
+    it("logs an error when the insert fails", async () => {
+      fetchMock.mockReset();
+      fetchMock.mockResolvedValue(new Response("boom", { status: 400 }));
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const { logToolCallResponse } = await import("../../lib/services/databricks/analytics.js");
+
+      logToolCallResponse({
+        tool: "Solana_Documentation_Search",
+        req: "find docs",
+        res: '{"content":[]}',
+        rawBody: {},
+      });
+
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(errorSpy).toHaveBeenCalledWith("[logToolCallResponse] Error inserting tool response:", expect.any(Error));
+      errorSpy.mockRestore();
+    });
+  });
+});

--- a/tests/unit/databricks.client.test.ts
+++ b/tests/unit/databricks.client.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const HOST = "https://dbc-test.cloud.databricks.com";
+const TOKEN = "dapi-test-token";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function textResponse(body: string, status: number): Response {
+  return new Response(body, { status });
+}
+
+describe("databricks client", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+    vi.useFakeTimers();
+    process.env.DATABRICKS_HOST = HOST;
+    process.env.DATABRICKS_TOKEN = TOKEN;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    delete process.env.DATABRICKS_HOST;
+    delete process.env.DATABRICKS_TOKEN;
+  });
+
+  describe("isDatabricksConfigured", () => {
+    it("returns false when host or token missing", async () => {
+      delete process.env.DATABRICKS_HOST;
+      const { isDatabricksConfigured } = await import("../../lib/services/databricks/client.js");
+      expect(isDatabricksConfigured()).toBe(false);
+    });
+
+    it("returns true when both set", async () => {
+      const { isDatabricksConfigured } = await import("../../lib/services/databricks/client.js");
+      expect(isDatabricksConfigured()).toBe(true);
+    });
+  });
+
+  describe("dbxFetch", () => {
+    it("throws when env vars missing", async () => {
+      delete process.env.DATABRICKS_TOKEN;
+      const { dbxFetch } = await import("../../lib/services/databricks/client.js");
+      await expect(dbxFetch("/anything")).rejects.toThrow(/not configured/i);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("sends bearer auth and parses JSON on success", async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true, n: 42 }));
+      const { dbxFetch } = await import("../../lib/services/databricks/client.js");
+
+      const result = await dbxFetch<{ n: number }>("/api/2.0/thing", {
+        method: "POST",
+        body: JSON.stringify({ a: 1 }),
+      });
+
+      expect(result).toEqual({ ok: true, n: 42 });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe(`${HOST}/api/2.0/thing`);
+      expect(init.method).toBe("POST");
+      const headers = new Headers(init.headers);
+      expect(headers.get("Authorization")).toBe(`Bearer ${TOKEN}`);
+      expect(headers.get("Content-Type")).toBe("application/json");
+    });
+
+    it("normalizes trailing slash on host and leading slash on path", async () => {
+      process.env.DATABRICKS_HOST = `${HOST}/`;
+      fetchMock.mockResolvedValueOnce(jsonResponse({}));
+      const { dbxFetch } = await import("../../lib/services/databricks/client.js");
+
+      await dbxFetch("api/2.0/ping");
+
+      const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe(`${HOST}/api/2.0/ping`);
+    });
+
+    it("retries on 429 then succeeds", async () => {
+      fetchMock
+        .mockResolvedValueOnce(textResponse("rate limited", 429))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      const { dbxFetch } = await import("../../lib/services/databricks/client.js");
+      const promise = dbxFetch<{ ok: boolean }>("/api/2.0/retry", { method: "GET" });
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      expect(result).toEqual({ ok: true });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries on 500 then succeeds", async () => {
+      fetchMock.mockResolvedValueOnce(textResponse("boom", 500)).mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      const { dbxFetch } = await import("../../lib/services/databricks/client.js");
+      const promise = dbxFetch("/api/2.0/flaky", { method: "GET" });
+      await vi.runAllTimersAsync();
+      await promise;
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws DatabricksError after exhausting retries on 500", async () => {
+      fetchMock.mockImplementation(async () => textResponse("persistent failure body", 500));
+
+      const { dbxFetch, DatabricksError } = await import("../../lib/services/databricks/client.js");
+      const promise = dbxFetch("/api/2.0/never", { method: "GET" });
+      promise.catch(() => undefined); // prevent unhandled-rejection during fake-timer advance
+      await vi.runAllTimersAsync();
+
+      await expect(promise).rejects.toBeInstanceOf(DatabricksError);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("falls back to OAuth M2M when only client_id + client_secret are set", async () => {
+      delete process.env.DATABRICKS_TOKEN;
+      process.env.DATABRICKS_CLIENT_ID = "sp-client-id";
+      process.env.DATABRICKS_CLIENT_SECRET = "sp-client-secret";
+
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ access_token: "oauth-token-xyz", expires_in: 3600 }))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      const { dbxFetch } = await import("../../lib/services/databricks/client.js");
+      await dbxFetch("/api/2.0/thing", { method: "GET" });
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const [oauthUrl, oauthInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(oauthUrl).toBe(`${HOST}/oidc/v1/token`);
+      expect(oauthInit.method).toBe("POST");
+      const oauthHeaders = new Headers(oauthInit.headers);
+      expect(oauthHeaders.get("Authorization")).toMatch(/^Basic /);
+      expect(oauthInit.body).toBe("grant_type=client_credentials&scope=all-apis");
+
+      const [apiUrl, apiInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+      expect(apiUrl).toBe(`${HOST}/api/2.0/thing`);
+      const apiHeaders = new Headers(apiInit.headers);
+      expect(apiHeaders.get("Authorization")).toBe("Bearer oauth-token-xyz");
+
+      delete process.env.DATABRICKS_CLIENT_ID;
+      delete process.env.DATABRICKS_CLIENT_SECRET;
+    });
+
+    it("throws DatabricksError immediately on 4xx (non-429)", async () => {
+      fetchMock.mockResolvedValueOnce(textResponse("bad request", 400));
+
+      const { dbxFetch, DatabricksError } = await import("../../lib/services/databricks/client.js");
+
+      await expect(dbxFetch("/api/2.0/bad")).rejects.toBeInstanceOf(DatabricksError);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/unit/databricks.vectorSearch.test.ts
+++ b/tests/unit/databricks.vectorSearch.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const HOST = "https://dbc-test.cloud.databricks.com";
+const TOKEN = "dapi-test-token";
+const INDEX = "test_catalog.test_schema.docs_chunks_idx";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("databricks vectorSearch", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+    process.env.DATABRICKS_HOST = HOST;
+    process.env.DATABRICKS_TOKEN = TOKEN;
+    process.env.DATABRICKS_VS_INDEX = INDEX;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.DATABRICKS_HOST;
+    delete process.env.DATABRICKS_TOKEN;
+    delete process.env.DATABRICKS_VS_INDEX;
+  });
+
+  it("returns [] and warns when index env missing, without calling fetch", async () => {
+    delete process.env.DATABRICKS_VS_INDEX;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");
+
+    const result = await searchDocs("whatever");
+    expect(result).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("returns [] when host/token missing, without calling fetch", async () => {
+    delete process.env.DATABRICKS_TOKEN;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");
+
+    const result = await searchDocs("whatever");
+    expect(result).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("POSTs to the query endpoint with oversampled num_results (k*3)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        manifest: {
+          columns: [
+            { name: "id" },
+            { name: "url" },
+            { name: "title" },
+            { name: "source_id" },
+            { name: "content" },
+            { name: "score" },
+          ],
+        },
+        result: { data_array: [] },
+      }),
+    );
+
+    const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");
+    await searchDocs("how to derive a PDA", 5);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${HOST}/api/2.0/vector-search/indexes/${INDEX}/query`);
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string) as {
+      query_text: string;
+      columns: string[];
+      num_results: number;
+    };
+    expect(body.query_text).toBe("how to derive a PDA");
+    expect(body.num_results).toBe(15);
+    expect(body.columns).toEqual(["id", "url", "title", "source_id", "content"]);
+  });
+
+  it("parses rows via manifest column order into DocChunk[]", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        manifest: {
+          columns: [
+            { name: "score" },
+            { name: "source_id" },
+            { name: "id" },
+            { name: "url" },
+            { name: "title" },
+            { name: "content" },
+          ],
+        },
+        result: {
+          data_array: [
+            [0.83, "gh-codama", "abc", "https://github.com/codama-idl/codama", "codama/README.md", "Codama overview"],
+            [0.71, "anchor-docs", "def", "https://www.anchor-lang.com/docs/pda", "Anchor PDA", "How to derive..."],
+            [0.5, null, "ghi", null, null, null],
+          ],
+        },
+      }),
+    );
+
+    const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");
+    const chunks = await searchDocs("pda");
+
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toEqual({
+      id: "abc",
+      url: "https://github.com/codama-idl/codama",
+      title: "codama/README.md",
+      sourceId: "gh-codama",
+      content: "Codama overview",
+      score: 0.83,
+    });
+    expect(chunks[2].sourceId).toBeNull();
+    expect(chunks[2].url).toBeNull();
+    expect(chunks[2].title).toBeNull();
+    expect(chunks[2].content).toBeNull();
+    expect(chunks[2].score).toBe(0.5);
+  });
+
+  it("dedupes chunks by URL, keeping highest-scored, then trims to k", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        manifest: {
+          columns: [
+            { name: "id" },
+            { name: "url" },
+            { name: "title" },
+            { name: "source_id" },
+            { name: "content" },
+            { name: "score" },
+          ],
+        },
+        result: {
+          data_array: [
+            ["a", "https://solana.com/versions", "Versioned", "solana-docs", "best chunk", 0.9],
+            ["b", "https://solana.com/versions", "Versioned", "solana-docs", "dup chunk", 0.89],
+            ["c", "https://solana.com/versions", "Versioned", "solana-docs", "another dup", 0.88],
+            ["d", "https://solana.com/pda", "PDA", "solana-docs", "pda content", 0.7],
+            ["e", "https://www.anchor-lang.com/pda", "Anchor PDA", "anchor-docs", "anchor content", 0.65],
+          ],
+        },
+      }),
+    );
+
+    const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");
+    const chunks = await searchDocs("versioned", 3);
+
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0].id).toBe("a");
+    expect(chunks[1].id).toBe("d");
+    expect(chunks[2].id).toBe("e");
+  });
+
+  it("falls back to id as dedupe key when url is null", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        manifest: {
+          columns: [
+            { name: "id" },
+            { name: "url" },
+            { name: "title" },
+            { name: "source_id" },
+            { name: "content" },
+            { name: "score" },
+          ],
+        },
+        result: {
+          data_array: [
+            ["id-1", null, "T1", null, "c1", 0.8],
+            ["id-2", null, "T2", null, "c2", 0.7],
+          ],
+        },
+      }),
+    );
+
+    const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");
+    const chunks = await searchDocs("x", 5);
+    expect(chunks.map(c => c.id)).toEqual(["id-1", "id-2"]);
+  });
+
+  it("handles empty result set", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        manifest: { columns: [{ name: "id" }, { name: "score" }] },
+        result: { data_array: [] },
+      }),
+    );
+
+    const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");
+    const chunks = await searchDocs("nothing matches");
+    expect(chunks).toEqual([]);
+  });
+});

--- a/tests/unit/formatChunks.test.ts
+++ b/tests/unit/formatChunks.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { DocChunk } from "../../lib/services/databricks/vectorSearch.js";
+import { formatChunksAsMarkdown } from "../../lib/tools/formatChunks.js";
+
+function chunk(overrides: Partial<DocChunk> = {}): DocChunk {
+  return {
+    id: "id-1",
+    url: "https://example.com/doc",
+    title: "Example Doc",
+    sourceId: "example-docs",
+    content: "Example content body",
+    score: 0.42,
+    ...overrides,
+  };
+}
+
+describe("formatChunksAsMarkdown", () => {
+  it("returns no-result message when chunks empty", () => {
+    const out = formatChunksAsMarkdown("how do I PDA", []);
+    expect(out).toContain("No relevant documentation found");
+    expect(out).toContain("how do I PDA");
+  });
+
+  it("renders a linked heading when title and url present", () => {
+    const out = formatChunksAsMarkdown("pda", [chunk()]);
+    expect(out).toContain("### 1. [Example Doc](https://example.com/doc)");
+    expect(out).toContain("score: 0.420");
+    expect(out).toContain("source: example-docs");
+    expect(out).toContain("Example content body");
+  });
+
+  it("falls back to title-only when url is missing", () => {
+    const out = formatChunksAsMarkdown("q", [chunk({ url: null })]);
+    expect(out).toContain("### 1. Example Doc");
+    expect(out).not.toContain("[Example Doc](");
+  });
+
+  it("falls back to url-only when title is missing", () => {
+    const out = formatChunksAsMarkdown("q", [chunk({ title: null })]);
+    expect(out).toContain("### 1. https://example.com/doc");
+  });
+
+  it("omits source label when sourceId missing", () => {
+    const out = formatChunksAsMarkdown("q", [chunk({ sourceId: null })]);
+    expect(out).toContain("score: 0.420");
+    expect(out).not.toContain("source: ");
+  });
+
+  it("numbers multiple chunks and separates them", () => {
+    const out = formatChunksAsMarkdown("pda", [
+      chunk({ id: "a", title: "Doc A" }),
+      chunk({ id: "b", title: "Doc B" }),
+      chunk({ id: "c", title: "Doc C" }),
+    ]);
+    expect(out).toContain('Top 3 matches for "pda"');
+    expect(out).toContain("### 1. [Doc A]");
+    expect(out).toContain("### 2. [Doc B]");
+    expect(out).toContain("### 3. [Doc C]");
+    expect(out.split("---").length).toBe(3); // 2 separators → 3 segments
+  });
+});

--- a/tests/unit/generalSolanaTools.test.ts
+++ b/tests/unit/generalSolanaTools.test.ts
@@ -1,9 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LanguageModel } from "ai";
+import type { DocChunk } from "../../lib/services/databricks/vectorSearch.js";
 
-const { generateTextMock, logAnalyticsMock } = vi.hoisted(() => ({
+const { generateTextMock, logAnalyticsMock, searchDocsMock } = vi.hoisted(() => ({
   generateTextMock: vi.fn(),
   logAnalyticsMock: vi.fn(),
+  searchDocsMock: vi.fn(),
 }));
 
 vi.mock("ai", () => ({
@@ -14,13 +16,23 @@ vi.mock("../../lib/analytics", () => ({
   logAnalytics: logAnalyticsMock,
 }));
 
+vi.mock("../../lib/services/databricks/vectorSearch.js", () => ({
+  searchDocs: searchDocsMock,
+}));
+
 import { createSolanaTools } from "../../lib/tools/generalSolanaTools";
 
 describe("createSolanaTools", () => {
   beforeEach(() => {
     generateTextMock.mockReset();
     logAnalyticsMock.mockReset();
+    searchDocsMock.mockReset();
     logAnalyticsMock.mockResolvedValue(undefined);
+    delete process.env.USE_DATABRICKS;
+  });
+
+  afterEach(() => {
+    delete process.env.USE_DATABRICKS;
   });
 
   it("returns explicit tool error when no model is configured", async () => {
@@ -93,6 +105,74 @@ describe("createSolanaTools", () => {
         req: searchQuery,
         res: "search-answer",
       },
+    });
+  });
+
+  describe("USE_DATABRICKS=1", () => {
+    beforeEach(() => {
+      process.env.USE_DATABRICKS = "1";
+    });
+
+    const sampleChunk: DocChunk = {
+      id: "chunk-1",
+      url: "https://www.solana-program.com/docs/pda",
+      title: "PDA Basics",
+      sourceId: "solana-program-site",
+      content: "A PDA is derived from seeds and program id.",
+      score: 0.812,
+    };
+
+    it("uses Databricks retrieval for ask tool, ignores model, skips generateText", async () => {
+      searchDocsMock.mockResolvedValueOnce([sampleChunk]);
+      const model = {} as unknown as LanguageModel;
+
+      const tools = createSolanaTools(model);
+      const askTool = tools.find(t => t.title === "Solana_Expert__Ask_For_Help");
+      if (!askTool) throw new Error("missing tool");
+
+      const result = await askTool.func({ question: "what is a PDA?" });
+
+      expect(searchDocsMock).toHaveBeenCalledWith("what is a PDA?", 8);
+      expect(generateTextMock).not.toHaveBeenCalled();
+      const text = (result as { content: [{ text: string }] }).content[0].text;
+      expect(text).toContain("PDA Basics");
+      expect(text).toContain("https://www.solana-program.com/docs/pda");
+      expect(text).toContain("source: solana-program-site");
+      expect(logAnalyticsMock).toHaveBeenCalledWith({
+        event_type: "message_response",
+        details: {
+          tool: "Solana_Expert__Ask_For_Help",
+          req: "what is a PDA?",
+          res: expect.stringContaining("PDA Basics"),
+        },
+      });
+    });
+
+    it("uses Databricks retrieval for search tool", async () => {
+      searchDocsMock.mockResolvedValueOnce([sampleChunk]);
+
+      const tools = createSolanaTools(null);
+      const searchTool = tools.find(t => t.title === "Solana_Documentation_Search");
+      if (!searchTool) throw new Error("missing tool");
+
+      const result = await searchTool.func({ query: "pda seeds" });
+
+      expect(searchDocsMock).toHaveBeenCalledWith("pda seeds", 8);
+      const text = (result as { content: [{ text: string }] }).content[0].text;
+      expect(text).toContain("PDA Basics");
+    });
+
+    it("returns no-result message when Databricks returns empty", async () => {
+      searchDocsMock.mockResolvedValueOnce([]);
+
+      const tools = createSolanaTools(null);
+      const searchTool = tools.find(t => t.title === "Solana_Documentation_Search");
+      if (!searchTool) throw new Error("missing tool");
+
+      const result = await searchTool.func({ query: "nothing matches" });
+
+      const text = (result as { content: [{ text: string }] }).content[0].text;
+      expect(text).toContain("No relevant documentation found");
     });
   });
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "tsup";
+import { readFileSync } from "node:fs";
+
+const pkg = JSON.parse(readFileSync("./package.json", "utf8")) as {
+  dependencies?: Record<string, string>;
+};
+
+export default defineConfig({
+  entry: ["api/start.ts"],
+  // Emit CJS: several deps (fp-ts, etc.) expose CJS with directory sub-paths
+  // that Node's ESM resolver rejects. CJS `require` handles them fine.
+  format: ["cjs"],
+  target: "node22",
+  clean: true,
+  outDir: "dist",
+  dts: false,
+  external: Object.keys(pkg.dependencies ?? {}),
+});


### PR DESCRIPTION
## Summary
- Add `USE_DATABRICKS=1` path that routes tool retrieval through Databricks Vector Search and analytics through Delta tables via SQL Statement Execution. Inkeep + Neon + Vercel path stays untouched when flag is off.
- New `lib/services/databricks/{client,vectorSearch,analytics}` services: fetch wrapper with PAT or OAuth M2M auth + retry, retrieval against `docs_chunks_idx` with oversample + URL dedupe, Neon-signature-compatible analytics writer.
- `api/start.ts` + `app.yaml` + `tsup` build pipeline for Databricks Apps (Node 22). Auto-disables SSE when no `REDIS_URL` so the App runs Redis-free.
- `ingestion/sources.yaml` (65 Solana corpus sources) + `ingestion/crawl_and_index` Databricks notebook: web/GitHub/OpenAPI crawlers, heading-aware chunking, locale + http URL filters, `MERGE INTO` Delta, triggers VS index sync.
- Tools return retrieved chunks as markdown when flag is on; LLM synthesis deferred (retrieval-only MVP).

## Test Plan
- `pnpm typecheck && pnpm test && pnpm lint` — all green (205 tests).
- `pnpm build` produces `dist/start.mjs` runnable under Node 22.
- Local smoke: `PORT=3999 node dist/start.mjs`, `POST /mcp` handshake + `tools/call Solana_Documentation_Search` returns relevant chunks.
- Deployed smoke: Databricks App at `solana-mcp-1125560347127367.aws.databricksapps.com` verified end-to-end — handshake, retrieval (~46k chunks, top score 0.742 on "how to derive a PDA"), analytics write to `prod.solana_mcp.mcp_tool_calls`.

## Rollout
- Flag off in prod; no behavior change on merge.
- Phase 6 (A/B + DNS cutover) tracked separately.

## Breaking Changes
None. Additive; original Inkeep/Neon modules untouched.