### PR TITLE
feat(inspect_entity): add enrichment resolvers core

### DIFF
--- a/lib/solana/anchor.ts
+++ b/lib/solana/anchor.ts
@@ -20,6 +20,8 @@ class ReadOnlyWallet {
   }
 }
 
+// TODO: cache providers per endpoint (Map<string, AnchorProvider>) to avoid
+// re-establishing connections on every call — parity with umiCache in metaplex-umi.ts
 export function createReadOnlyProvider(cluster: SupportedCluster): AnchorProvider {
   const endpoint = resolveRpcEndpoint(cluster);
   const connection = new Connection(endpoint, {

--- a/lib/solana/anchor.ts
+++ b/lib/solana/anchor.ts
@@ -1,0 +1,41 @@
+import { AnchorProvider, type Idl, Program } from "@coral-xyz/anchor";
+import { Connection, Keypair, PublicKey, type Transaction, type VersionedTransaction } from "@solana/web3.js";
+
+import { RPC_REQUEST_TIMEOUT_MS, type SupportedCluster } from "./constants";
+import { resolveRpcEndpoint } from "./rpc";
+
+const READONLY_WALLET_KEYPAIR = Keypair.generate();
+
+class ReadOnlyWallet {
+  get publicKey(): PublicKey {
+    return READONLY_WALLET_KEYPAIR.publicKey;
+  }
+
+  async signTransaction<T extends Transaction | VersionedTransaction>(tx: T): Promise<T> {
+    return tx;
+  }
+
+  async signAllTransactions<T extends Transaction | VersionedTransaction>(txs: T[]): Promise<T[]> {
+    return txs;
+  }
+}
+
+export function createReadOnlyProvider(cluster: SupportedCluster): AnchorProvider {
+  const endpoint = resolveRpcEndpoint(cluster);
+  const connection = new Connection(endpoint, {
+    fetch: (input, init) =>
+      fetch(input, {
+        ...init,
+        signal: AbortSignal.timeout(RPC_REQUEST_TIMEOUT_MS),
+      }),
+  });
+  return new AnchorProvider(connection, new ReadOnlyWallet(), {});
+}
+
+export async function fetchAnchorIdl(programId: string, provider: AnchorProvider): Promise<Idl | null> {
+  return Program.fetchIdl<Idl>(new PublicKey(programId), provider);
+}
+
+export async function createAnchorProgram(idl: Idl, provider: AnchorProvider): Promise<Program<Idl>> {
+  return new Program(idl, provider);
+}

--- a/lib/solana/inspect-entity.ts
+++ b/lib/solana/inspect-entity.ts
@@ -17,18 +17,13 @@ import type {
   SecurityMetadataResult,
   VerificationResult,
 } from "./types";
-import { resolveMetaplexMetadata } from "./metaplex-metadata";
+import { resolveMetaplexMetadata } from "./resolvers/metaplex-metadata";
 import { fetchAccountInfo, fetchAsset, fetchSignatureStatus, fetchTransaction, isSourceUnavailableError } from "./rpc";
 import { SUPPORTED_CLUSTERS, type SupportedCluster } from "./constants";
-import {
-  currentlyUnsupported,
-  internalError,
-  invalidArgument,
-  notFound,
-  sanitizeToolError,
-  toToolResult,
-} from "./errors";
+import { type McpToolError, internalError, invalidArgument, notFound, sanitizeToolError, toToolResult } from "./errors";
 import { enrichUpgradeableProgramData, normalizeAccountProbe } from "./account-normalizer";
+import { normalizeTransactionProbe } from "./transaction/normalizer";
+import { buildTransactionPayload } from "./transaction/build-payload";
 import { logger } from "../observability/logger";
 
 export const inspectEntityInputSchema = z
@@ -64,7 +59,6 @@ type InspectEntityDependencies = {
   fetchSignatureStatus: typeof fetchSignatureStatus;
 };
 
-// Enrichment resolvers stubbed until Steps 5-6 port the real implementations.
 const defaultDependencies: InspectEntityDependencies = {
   fetchAccountInfo,
   fetchTransaction,
@@ -91,6 +85,13 @@ function toNotFoundPayload(kind: "account" | "transaction"): Record<string, unkn
     entity: {
       kind,
     },
+  };
+}
+
+function safeCatch<T>(resolver: string, identifier: string, fallback: T) {
+  return (error: unknown): T => {
+    logger.warn({ event: "inspect_entity.safety_catch", resolver, identifier, error });
+    return fallback;
   };
 }
 
@@ -132,46 +133,29 @@ async function resolveAccount(
             enrichedAccount.programDataRawBase64 ?? null,
             cluster,
           )
-          .catch((error): VerificationResult => {
-            logger.warn({
-              event: "inspect_entity.safety_catch",
-              resolver: "verification",
-              identifier,
-              error,
-            });
-            return { status: "unknown", reason: "source_unavailable" };
-          }),
+          .catch(
+            safeCatch<VerificationResult>("verification", identifier, {
+              status: "unknown",
+              reason: "source_unavailable",
+            }),
+          ),
         dependencies
           .resolveProgramSecurityMetadata(identifier, enrichedAccount.programDataRawBase64 ?? null, cluster)
-          .catch((error): SecurityMetadataResult => {
-            logger.warn({
-              event: "inspect_entity.safety_catch",
-              resolver: "security_metadata",
-              identifier,
-              error,
-            });
-            return { status: "unknown", reason: "source_unavailable" };
+          .catch(
+            safeCatch<SecurityMetadataResult>("security_metadata", identifier, {
+              status: "unknown",
+              reason: "source_unavailable",
+            }),
+          ),
+        dependencies.resolveMultisigReference(enrichedAccount.programData?.authority ?? null, cluster).catch(
+          safeCatch<MultisigReferenceResult>("multisig", identifier, {
+            status: "unknown",
+            reason: "source_unavailable",
           }),
+        ),
         dependencies
-          .resolveMultisigReference(enrichedAccount.programData?.authority ?? null, cluster)
-          .catch((error): MultisigReferenceResult => {
-            logger.warn({
-              event: "inspect_entity.safety_catch",
-              resolver: "multisig",
-              identifier,
-              error,
-            });
-            return { status: "unknown", reason: "source_unavailable" };
-          }),
-        dependencies.resolveProgramIdl(identifier, cluster).catch((error): IdlDiscoveryResult => {
-          logger.warn({
-            event: "inspect_entity.safety_catch",
-            resolver: "idl",
-            identifier,
-            error,
-          });
-          return { status: "unknown", reason: "source_unavailable" };
-        }),
+          .resolveProgramIdl(identifier, cluster)
+          .catch(safeCatch<IdlDiscoveryResult>("idl", identifier, { status: "unknown", reason: "source_unavailable" })),
       ]);
     }
 
@@ -182,12 +166,7 @@ async function resolveAccount(
         const rawAsset = await dependencies.fetchAsset(identifier, cluster);
         dasOutcome = normalizeDasOutcome(rawAsset);
       } catch (error) {
-        logger.warn({
-          event: "inspect_entity.safety_catch",
-          resolver: "das",
-          identifier,
-          error,
-        });
+        logger.warn({ event: "inspect_entity.safety_catch", resolver: "das", identifier, error });
         dasOutcome = null;
       }
     }
@@ -197,17 +176,12 @@ async function resolveAccount(
     let metaplexMetadataResult: MetaplexMetadataResult | undefined;
 
     if (finalKind === "spl-token:mint" || finalKind === "spl-token-2022:mint") {
-      metaplexMetadataResult = await dependencies
-        .resolveMetaplexMetadata(identifier, cluster)
-        .catch((error): MetaplexMetadataResult => {
-          logger.warn({
-            event: "inspect_entity.safety_catch",
-            resolver: "metaplex_metadata",
-            identifier,
-            error,
-          });
-          return { status: "unknown", reason: "source_unavailable" };
-        });
+      metaplexMetadataResult = await dependencies.resolveMetaplexMetadata(identifier, cluster).catch(
+        safeCatch<MetaplexMetadataResult>("metaplex_metadata", identifier, {
+          status: "unknown",
+          reason: "source_unavailable",
+        }),
+      );
     }
 
     const payload = buildAccountPayload({
@@ -246,16 +220,62 @@ async function resolveAccount(
   }
 }
 
-// Transaction resolution — stub until Step 4 ports the real normalizer/builder.
 async function resolveTransaction(
-  _identifier: string,
-  _cluster: SupportedCluster,
-  _dependencies: InspectEntityDependencies,
+  identifier: string,
+  cluster: SupportedCluster,
+  dependencies: InspectEntityDependencies,
 ): Promise<CallToolResult> {
-  return toToolResult({
-    payload: {},
-    errors: [currentlyUnsupported("Transaction inspection is not yet available.")],
-  });
+  try {
+    const [transactionProbe, signatureStatus] = await Promise.all([
+      dependencies.fetchTransaction(identifier, cluster),
+      dependencies.fetchSignatureStatus(identifier, cluster).catch(error => {
+        logger.warn({
+          event: "inspect_entity.safety_catch",
+          resolver: "signature_status",
+          identifier,
+          error,
+        });
+        return null;
+      }),
+    ]);
+    const transactionContext = normalizeTransactionProbe(identifier, transactionProbe, signatureStatus);
+
+    if (transactionContext === null) {
+      return toToolResult({
+        payload: toNotFoundPayload("transaction"),
+        errors: [notFound()],
+      });
+    }
+
+    const errors: McpToolError[] = [];
+    if (signatureStatus === null) {
+      errors.push(internalError("Confirmation status temporarily unavailable."));
+    }
+
+    return toToolResult({
+      payload: buildTransactionPayload(transactionContext),
+      errors,
+      isError: false,
+    });
+  } catch (error) {
+    logger.error({
+      event: "inspect_entity.resolve_transaction_failed",
+      identifier,
+      error,
+    });
+
+    if (isSourceUnavailableError(error)) {
+      return toToolResult({
+        payload: toSourceUnavailablePayload("transaction"),
+        errors: [internalError()],
+      });
+    }
+
+    return toToolResult({
+      payload: {},
+      errors: [internalError()],
+    });
+  }
 }
 
 export async function handleInspectEntity(

--- a/lib/solana/resolvers/metaplex-metadata.ts
+++ b/lib/solana/resolvers/metaplex-metadata.ts
@@ -1,17 +1,12 @@
-import {
-  fetchMetadata,
-  findMetadataPda,
-  mplTokenMetadata,
-  type Metadata,
-  TokenStandard,
-} from "@metaplex-foundation/mpl-token-metadata";
+import { fetchMetadata, findMetadataPda, type Metadata, TokenStandard } from "@metaplex-foundation/mpl-token-metadata";
 import { publicKey, type Umi } from "@metaplex-foundation/umi";
 import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
+import { mplTokenMetadata } from "@metaplex-foundation/mpl-token-metadata";
 
-import { resolveRpcEndpoint } from "./rpc";
-import { METAPLEX_METADATA_TIMEOUT_MS, type SupportedCluster } from "./constants";
-import { raceWithTimeout } from "./timeout";
-import { logger } from "../observability/logger";
+import { resolveRpcEndpoint } from "../rpc";
+import { METAPLEX_METADATA_TIMEOUT_MS, type SupportedCluster } from "../constants";
+import { raceWithTimeout } from "../timeout";
+import { logger } from "../../observability/logger";
 
 const TOKEN_STANDARD_LABELS: Record<number, MetaplexTokenStandard> = {
   [TokenStandard.NonFungible]: "NonFungible",

--- a/lib/solana/resolvers/metaplex-metadata.ts
+++ b/lib/solana/resolvers/metaplex-metadata.ts
@@ -21,6 +21,8 @@ export async function resolveMetaplexMetadata(
     return normalizeMetadata(metadata);
   } catch (error) {
     // UMI throws when the account doesn't exist (e.g., fungible tokens without metadata)
+    // TODO(@rogaldh): tighten error-substring classifier — match specific UMI error
+    // types or codes instead of fragile substring checks.
     const message = error instanceof Error ? error.message : String(error);
     if (
       message.includes("could not find account") ||

--- a/lib/solana/resolvers/metaplex-metadata.ts
+++ b/lib/solana/resolvers/metaplex-metadata.ts
@@ -1,4 +1,10 @@
-import { fetchMetadata, findMetadataPda, mplTokenMetadata, type Metadata, TokenStandard } from "@metaplex-foundation/mpl-token-metadata";
+import {
+  fetchMetadata,
+  findMetadataPda,
+  mplTokenMetadata,
+  type Metadata,
+  TokenStandard,
+} from "@metaplex-foundation/mpl-token-metadata";
 import { publicKey, type Umi } from "@metaplex-foundation/umi";
 import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
 

--- a/lib/solana/resolvers/metaplex-metadata.ts
+++ b/lib/solana/resolvers/metaplex-metadata.ts
@@ -1,7 +1,6 @@
-import { fetchMetadata, findMetadataPda, type Metadata, TokenStandard } from "@metaplex-foundation/mpl-token-metadata";
+import { fetchMetadata, findMetadataPda, mplTokenMetadata, type Metadata, TokenStandard } from "@metaplex-foundation/mpl-token-metadata";
 import { publicKey, type Umi } from "@metaplex-foundation/umi";
 import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
-import { mplTokenMetadata } from "@metaplex-foundation/mpl-token-metadata";
 
 import { resolveRpcEndpoint } from "../rpc";
 import { METAPLEX_METADATA_TIMEOUT_MS, type SupportedCluster } from "../constants";

--- a/lib/solana/resolvers/metaplex-metadata.ts
+++ b/lib/solana/resolvers/metaplex-metadata.ts
@@ -1,134 +1,23 @@
-import {
-  fetchMetadata,
-  findMetadataPda,
-  mplTokenMetadata,
-  type Metadata,
-  TokenStandard,
-} from "@metaplex-foundation/mpl-token-metadata";
-import { publicKey, type Umi } from "@metaplex-foundation/umi";
-import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
-
-import { resolveRpcEndpoint } from "../rpc";
-import { METAPLEX_METADATA_TIMEOUT_MS, type SupportedCluster } from "../constants";
-import { raceWithTimeout } from "../timeout";
+import type { SupportedCluster } from "../constants";
+import type { MetaplexMetadataResult } from "./metaplex-normalize";
+import { fetchRawMetaplexMetadata } from "./metaplex-umi";
+import { normalizeMetadata } from "./metaplex-normalize";
 import { logger } from "../../observability/logger";
 
-const TOKEN_STANDARD_LABELS: Record<number, MetaplexTokenStandard> = {
-  [TokenStandard.NonFungible]: "NonFungible",
-  [TokenStandard.FungibleAsset]: "FungibleAsset",
-  [TokenStandard.Fungible]: "Fungible",
-  [TokenStandard.NonFungibleEdition]: "NonFungibleEdition",
-  [TokenStandard.ProgrammableNonFungible]: "ProgrammableNonFungible",
-  [TokenStandard.ProgrammableNonFungibleEdition]: "ProgrammableNonFungibleEdition",
-};
-
-export type MetaplexTokenStandard =
-  | "NonFungible"
-  | "FungibleAsset"
-  | "Fungible"
-  | "NonFungibleEdition"
-  | "ProgrammableNonFungible"
-  | "ProgrammableNonFungibleEdition";
-
-export type MetaplexCreator = {
-  address: string;
-  verified: boolean;
-  share: number;
-};
-
-export type MetaplexCollection = {
-  verified: boolean;
-  key: string;
-};
-
-export type MetaplexMetadataFound = {
-  status: "found";
-  name: string;
-  symbol: string;
-  uri: string;
-  seller_fee_basis_points: number;
-  creators: MetaplexCreator[] | null;
-  token_standard: MetaplexTokenStandard | null;
-  collection: MetaplexCollection | null;
-  is_collection: boolean;
-  primary_sale_happened: boolean;
-  is_mutable: boolean;
-};
-
-export type MetaplexMetadataResult =
-  | MetaplexMetadataFound
-  | { status: "not_found" }
-  | { status: "unknown"; reason: "source_unavailable" };
-
-// Per-endpoint UMI cache (same pattern as solana-explorer)
-const umiCache = new Map<string, Umi>();
-
-function getUmi(rpcEndpoint: string): Umi {
-  let umi = umiCache.get(rpcEndpoint);
-  if (!umi) {
-    umi = createUmi(rpcEndpoint).use(mplTokenMetadata());
-    umiCache.set(rpcEndpoint, umi);
-  }
-  return umi;
-}
-
-function isSome<T>(
-  option: { __option: "Some"; value: T } | { __option: "None" },
-): option is { __option: "Some"; value: T } {
-  return option.__option === "Some";
-}
-
-function normalizeMetadata(metadata: Metadata): MetaplexMetadataFound {
-  const tokenStandard = isSome(metadata.tokenStandard)
-    ? (TOKEN_STANDARD_LABELS[metadata.tokenStandard.value] ?? null)
-    : null;
-
-  const collection = isSome(metadata.collection)
-    ? { verified: metadata.collection.value.verified, key: metadata.collection.value.key.toString() }
-    : null;
-
-  const creators = isSome(metadata.creators)
-    ? metadata.creators.value.map(c => ({
-        address: c.address.toString(),
-        verified: c.verified,
-        share: c.share,
-      }))
-    : null;
-
-  const isCollection = isSome(metadata.collectionDetails);
-
-  return {
-    status: "found",
-    name: metadata.name.replace(/\0/g, "").trim(),
-    symbol: metadata.symbol.replace(/\0/g, "").trim(),
-    uri: metadata.uri.replace(/\0/g, "").trim(),
-    seller_fee_basis_points: metadata.sellerFeeBasisPoints,
-    creators,
-    token_standard: tokenStandard,
-    collection,
-    is_collection: isCollection,
-    primary_sale_happened: metadata.primarySaleHappened,
-    is_mutable: metadata.isMutable,
-  };
-}
+export type {
+  MetaplexTokenStandard,
+  MetaplexCreator,
+  MetaplexCollection,
+  MetaplexMetadataFound,
+  MetaplexMetadataResult,
+} from "./metaplex-normalize";
 
 export async function resolveMetaplexMetadata(
   mintAddress: string,
   cluster: SupportedCluster,
 ): Promise<MetaplexMetadataResult> {
-  const endpoint = resolveRpcEndpoint(cluster);
-  const umi = getUmi(endpoint);
-
   try {
-    const mintKey = publicKey(mintAddress);
-    const metadataPda = findMetadataPda(umi, { mint: mintKey });
-
-    const metadata = await raceWithTimeout(
-      fetchMetadata(umi, metadataPda),
-      METAPLEX_METADATA_TIMEOUT_MS,
-      "Metaplex metadata fetch",
-    );
-
+    const metadata = await fetchRawMetaplexMetadata(mintAddress, cluster);
     return normalizeMetadata(metadata);
   } catch (error) {
     // UMI throws when the account doesn't exist (e.g., fungible tokens without metadata)

--- a/lib/solana/resolvers/metaplex-normalize.ts
+++ b/lib/solana/resolvers/metaplex-normalize.ts
@@ -1,0 +1,88 @@
+import { type Metadata, TokenStandard } from "@metaplex-foundation/mpl-token-metadata";
+
+export type MetaplexTokenStandard =
+  | "NonFungible"
+  | "FungibleAsset"
+  | "Fungible"
+  | "NonFungibleEdition"
+  | "ProgrammableNonFungible"
+  | "ProgrammableNonFungibleEdition";
+
+export type MetaplexCreator = {
+  address: string;
+  verified: boolean;
+  share: number;
+};
+
+export type MetaplexCollection = {
+  verified: boolean;
+  key: string;
+};
+
+export type MetaplexMetadataFound = {
+  status: "found";
+  name: string;
+  symbol: string;
+  uri: string;
+  seller_fee_basis_points: number;
+  creators: MetaplexCreator[] | null;
+  token_standard: MetaplexTokenStandard | null;
+  collection: MetaplexCollection | null;
+  is_collection: boolean;
+  primary_sale_happened: boolean;
+  is_mutable: boolean;
+};
+
+export type MetaplexMetadataResult =
+  | MetaplexMetadataFound
+  | { status: "not_found" }
+  | { status: "unknown"; reason: "source_unavailable" };
+
+const TOKEN_STANDARD_LABELS: Record<number, MetaplexTokenStandard> = {
+  [TokenStandard.NonFungible]: "NonFungible",
+  [TokenStandard.FungibleAsset]: "FungibleAsset",
+  [TokenStandard.Fungible]: "Fungible",
+  [TokenStandard.NonFungibleEdition]: "NonFungibleEdition",
+  [TokenStandard.ProgrammableNonFungible]: "ProgrammableNonFungible",
+  [TokenStandard.ProgrammableNonFungibleEdition]: "ProgrammableNonFungibleEdition",
+};
+
+function isSome<T>(
+  option: { __option: "Some"; value: T } | { __option: "None" },
+): option is { __option: "Some"; value: T } {
+  return option.__option === "Some";
+}
+
+export function normalizeMetadata(metadata: Metadata): MetaplexMetadataFound {
+  const tokenStandard = isSome(metadata.tokenStandard)
+    ? (TOKEN_STANDARD_LABELS[metadata.tokenStandard.value] ?? null)
+    : null;
+
+  const collection = isSome(metadata.collection)
+    ? { verified: metadata.collection.value.verified, key: metadata.collection.value.key.toString() }
+    : null;
+
+  const creators = isSome(metadata.creators)
+    ? metadata.creators.value.map(c => ({
+        address: c.address.toString(),
+        verified: c.verified,
+        share: c.share,
+      }))
+    : null;
+
+  const isCollection = isSome(metadata.collectionDetails);
+
+  return {
+    status: "found",
+    name: metadata.name.replace(/\0/g, "").trim(),
+    symbol: metadata.symbol.replace(/\0/g, "").trim(),
+    uri: metadata.uri.replace(/\0/g, "").trim(),
+    seller_fee_basis_points: metadata.sellerFeeBasisPoints,
+    creators,
+    token_standard: tokenStandard,
+    collection,
+    is_collection: isCollection,
+    primary_sale_happened: metadata.primarySaleHappened,
+    is_mutable: metadata.isMutable,
+  };
+}

--- a/lib/solana/resolvers/metaplex-umi.ts
+++ b/lib/solana/resolvers/metaplex-umi.ts
@@ -1,0 +1,41 @@
+import {
+  fetchMetadata,
+  findMetadataPda,
+  mplTokenMetadata,
+  type Metadata,
+} from "@metaplex-foundation/mpl-token-metadata";
+import { publicKey, type Umi } from "@metaplex-foundation/umi";
+import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
+
+import { resolveRpcEndpoint } from "../rpc";
+import { METAPLEX_METADATA_TIMEOUT_MS, type SupportedCluster } from "../constants";
+import { raceWithTimeout } from "../timeout";
+
+// Per-endpoint UMI cache (same pattern as solana-explorer)
+const umiCache = new Map<string, Umi>();
+
+function getUmi(rpcEndpoint: string): Umi {
+  let umi = umiCache.get(rpcEndpoint);
+  if (!umi) {
+    umi = createUmi(rpcEndpoint).use(mplTokenMetadata());
+    umiCache.set(rpcEndpoint, umi);
+  }
+  return umi;
+}
+
+export async function fetchRawMetaplexMetadata(
+  mintAddress: string,
+  cluster: SupportedCluster,
+): Promise<Metadata> {
+  const endpoint = resolveRpcEndpoint(cluster);
+  const umi = getUmi(endpoint);
+
+  const mintKey = publicKey(mintAddress);
+  const metadataPda = findMetadataPda(umi, { mint: mintKey });
+
+  return raceWithTimeout(
+    fetchMetadata(umi, metadataPda),
+    METAPLEX_METADATA_TIMEOUT_MS,
+    "Metaplex metadata fetch",
+  );
+}

--- a/lib/solana/resolvers/metaplex-umi.ts
+++ b/lib/solana/resolvers/metaplex-umi.ts
@@ -23,19 +23,12 @@ function getUmi(rpcEndpoint: string): Umi {
   return umi;
 }
 
-export async function fetchRawMetaplexMetadata(
-  mintAddress: string,
-  cluster: SupportedCluster,
-): Promise<Metadata> {
+export async function fetchRawMetaplexMetadata(mintAddress: string, cluster: SupportedCluster): Promise<Metadata> {
   const endpoint = resolveRpcEndpoint(cluster);
   const umi = getUmi(endpoint);
 
   const mintKey = publicKey(mintAddress);
   const metadataPda = findMetadataPda(umi, { mint: mintKey });
 
-  return raceWithTimeout(
-    fetchMetadata(umi, metadataPda),
-    METAPLEX_METADATA_TIMEOUT_MS,
-    "Metaplex metadata fetch",
-  );
+  return raceWithTimeout(fetchMetadata(umi, metadataPda), METAPLEX_METADATA_TIMEOUT_MS, "Metaplex metadata fetch");
 }

--- a/lib/solana/transaction/account-resolver.ts
+++ b/lib/solana/transaction/account-resolver.ts
@@ -1,0 +1,95 @@
+import type { ResolvedAccount, TransactionVersion } from "../types";
+
+type MessageHeader = {
+  numRequiredSignatures: number;
+  numReadonlySignedAccounts: number;
+  numReadonlyUnsignedAccounts: number;
+};
+
+type LoadedAddresses = {
+  readonly writable: readonly string[];
+  readonly readonly: readonly string[];
+};
+
+type AccountResolutionParams = {
+  staticKeys: string[];
+  header: MessageHeader;
+  loadedAddresses?: LoadedAddresses | null;
+};
+
+type AccountResolutionResult = {
+  accountKeys: string[];
+  resolvedAccounts: ResolvedAccount[];
+};
+
+type TransactionAccountResolver = (params: AccountResolutionParams) => AccountResolutionResult;
+
+function classifyStaticKeys(staticKeys: string[], header: MessageHeader): ResolvedAccount[] {
+  const { numRequiredSignatures, numReadonlySignedAccounts, numReadonlyUnsignedAccounts } = header;
+  const readonlySignerStart = numRequiredSignatures - numReadonlySignedAccounts;
+  const readonlyUnsignedStart = staticKeys.length - numReadonlyUnsignedAccounts;
+
+  return staticKeys.map((address, i) => {
+    const signer = i < numRequiredSignatures;
+    const readonlySigned = signer && i >= readonlySignerStart;
+    const readonlyUnsigned = !signer && i >= readonlyUnsignedStart;
+    const writable = !readonlySigned && !readonlyUnsigned;
+    return { address, signer, writable };
+  });
+}
+
+export function resolveStaticAccounts(params: AccountResolutionParams): AccountResolutionResult {
+  const { staticKeys, header } = params;
+  return {
+    accountKeys: staticKeys,
+    resolvedAccounts: classifyStaticKeys(staticKeys, header),
+  };
+}
+
+export function resolveV0Accounts(params: AccountResolutionParams): AccountResolutionResult {
+  const { staticKeys, header, loadedAddresses } = params;
+  const staticAccounts = classifyStaticKeys(staticKeys, header);
+
+  const loadedWritable = loadedAddresses?.writable ?? [];
+  const loadedReadonly = loadedAddresses?.readonly ?? [];
+
+  const loadedWritableAccounts: ResolvedAccount[] = loadedWritable.map(address => ({
+    address,
+    signer: false,
+    writable: true,
+  }));
+
+  const loadedReadonlyAccounts: ResolvedAccount[] = loadedReadonly.map(address => ({
+    address,
+    signer: false,
+    writable: false,
+  }));
+
+  return {
+    accountKeys: [
+      ...staticKeys,
+      ...loadedWritable,
+      ...loadedReadonly,
+    ],
+    resolvedAccounts: [
+      ...staticAccounts,
+      ...loadedWritableAccounts,
+      ...loadedReadonlyAccounts,
+    ],
+  };
+}
+
+export function selectAccountResolver(version: TransactionVersion): TransactionAccountResolver {
+  switch (version) {
+    case "legacy":
+    case null:
+    case 1:
+      return resolveStaticAccounts;
+    case 0:
+      return resolveV0Accounts;
+    default: {
+      const _exhaustive: never = version;
+      throw new Error(`Unhandled transaction version: ${String(_exhaustive)}`);
+    }
+  }
+}

--- a/lib/solana/transaction/account-resolver.ts
+++ b/lib/solana/transaction/account-resolver.ts
@@ -46,9 +46,10 @@ function classifyStaticKeys(staticKeys: string[], header: MessageHeader): Resolv
  * correspond 1:1 with the flattened `loadedAddresses.writable` and
  * `loadedAddresses.readonly` arrays respectively.
  */
-function buildLookupTableMap(
-  addressTableLookups: readonly AddressTableLookup[] | undefined,
-): { writableMap: string[]; readonlyMap: string[] } {
+function buildLookupTableMap(addressTableLookups: readonly AddressTableLookup[] | undefined): {
+  writableMap: string[];
+  readonlyMap: string[];
+} {
   const writableMap: string[] = [];
   const readonlyMap: string[] = [];
 
@@ -102,16 +103,8 @@ export function resolveV0Accounts(params: AccountResolutionParams): AccountResol
   }));
 
   return {
-    accountKeys: [
-      ...staticKeys,
-      ...loadedWritable,
-      ...loadedReadonly,
-    ],
-    resolvedAccounts: [
-      ...staticAccounts,
-      ...loadedWritableAccounts,
-      ...loadedReadonlyAccounts,
-    ],
+    accountKeys: [...staticKeys, ...loadedWritable, ...loadedReadonly],
+    resolvedAccounts: [...staticAccounts, ...loadedWritableAccounts, ...loadedReadonlyAccounts],
   };
 }
 

--- a/lib/solana/transaction/account-resolver.ts
+++ b/lib/solana/transaction/account-resolver.ts
@@ -135,6 +135,7 @@ export function selectAccountResolver(version: TransactionVersion): TransactionA
   switch (version) {
     case "legacy":
     case null:
+    // SIMD-0385 v1 uses a flat address array with no ALTs — same resolution as legacy.
     case 1:
       return resolveStaticAccounts;
     case 0:

--- a/lib/solana/transaction/account-resolver.ts
+++ b/lib/solana/transaction/account-resolver.ts
@@ -1,4 +1,5 @@
 import type { AddressTableLookup, ResolvedAccount, TransactionVersion } from "../types";
+import { logger } from "../../observability/logger";
 
 type MessageHeader = {
   numRequiredSignatures: number;
@@ -81,10 +82,32 @@ export function resolveV0Accounts(params: AccountResolutionParams): AccountResol
   const { staticKeys, header, loadedAddresses, addressTableLookups } = params;
   const staticAccounts = classifyStaticKeys(staticKeys, header);
 
+  if (addressTableLookups?.length && !loadedAddresses) {
+    logger.warn({
+      event: "account_resolver.v0_missing_loaded_addresses",
+      lookupCount: addressTableLookups.length,
+    });
+  }
+
   const loadedWritable = loadedAddresses?.writable ?? [];
   const loadedReadonly = loadedAddresses?.readonly ?? [];
 
   const { writableMap, readonlyMap } = buildLookupTableMap(addressTableLookups);
+
+  if (addressTableLookups && loadedWritable.length !== writableMap.length) {
+    logger.warn({
+      event: "account_resolver.writable_lookup_mismatch",
+      loadedCount: loadedWritable.length,
+      lookupCount: writableMap.length,
+    });
+  }
+  if (addressTableLookups && loadedReadonly.length !== readonlyMap.length) {
+    logger.warn({
+      event: "account_resolver.readonly_lookup_mismatch",
+      loadedCount: loadedReadonly.length,
+      lookupCount: readonlyMap.length,
+    });
+  }
 
   const loadedWritableAccounts: ResolvedAccount[] = loadedWritable.map((address, i) => ({
     address,

--- a/lib/solana/transaction/account-resolver.ts
+++ b/lib/solana/transaction/account-resolver.ts
@@ -1,4 +1,4 @@
-import type { ResolvedAccount, TransactionVersion } from "../types";
+import type { AddressTableLookup, ResolvedAccount, TransactionVersion } from "../types";
 
 type MessageHeader = {
   numRequiredSignatures: number;
@@ -15,6 +15,7 @@ type AccountResolutionParams = {
   staticKeys: string[];
   header: MessageHeader;
   loadedAddresses?: LoadedAddresses | null;
+  addressTableLookups?: readonly AddressTableLookup[];
 };
 
 type AccountResolutionResult = {
@@ -34,8 +35,37 @@ function classifyStaticKeys(staticKeys: string[], header: MessageHeader): Resolv
     const readonlySigned = signer && i >= readonlySignerStart;
     const readonlyUnsigned = !signer && i >= readonlyUnsignedStart;
     const writable = !readonlySigned && !readonlyUnsigned;
-    return { address, signer, writable };
+    return { address, signer, writable, source: "static" as const };
   });
+}
+
+/**
+ * Build a mapping from loaded address position to its source ALT account.
+ *
+ * `addressTableLookups` entries are ordered — their writable/readonly counts
+ * correspond 1:1 with the flattened `loadedAddresses.writable` and
+ * `loadedAddresses.readonly` arrays respectively.
+ */
+function buildLookupTableMap(
+  addressTableLookups: readonly AddressTableLookup[] | undefined,
+): { writableMap: string[]; readonlyMap: string[] } {
+  const writableMap: string[] = [];
+  const readonlyMap: string[] = [];
+
+  if (!addressTableLookups) {
+    return { writableMap, readonlyMap };
+  }
+
+  for (const lookup of addressTableLookups) {
+    for (let i = 0; i < lookup.writableIndexes.length; i++) {
+      writableMap.push(lookup.accountKey);
+    }
+    for (let i = 0; i < lookup.readonlyIndexes.length; i++) {
+      readonlyMap.push(lookup.accountKey);
+    }
+  }
+
+  return { writableMap, readonlyMap };
 }
 
 export function resolveStaticAccounts(params: AccountResolutionParams): AccountResolutionResult {
@@ -47,22 +77,28 @@ export function resolveStaticAccounts(params: AccountResolutionParams): AccountR
 }
 
 export function resolveV0Accounts(params: AccountResolutionParams): AccountResolutionResult {
-  const { staticKeys, header, loadedAddresses } = params;
+  const { staticKeys, header, loadedAddresses, addressTableLookups } = params;
   const staticAccounts = classifyStaticKeys(staticKeys, header);
 
   const loadedWritable = loadedAddresses?.writable ?? [];
   const loadedReadonly = loadedAddresses?.readonly ?? [];
 
-  const loadedWritableAccounts: ResolvedAccount[] = loadedWritable.map(address => ({
+  const { writableMap, readonlyMap } = buildLookupTableMap(addressTableLookups);
+
+  const loadedWritableAccounts: ResolvedAccount[] = loadedWritable.map((address, i) => ({
     address,
     signer: false,
     writable: true,
+    source: "lookupTable" as const,
+    ...(writableMap[i] != null && { lookupTableAddress: writableMap[i] }),
   }));
 
-  const loadedReadonlyAccounts: ResolvedAccount[] = loadedReadonly.map(address => ({
+  const loadedReadonlyAccounts: ResolvedAccount[] = loadedReadonly.map((address, i) => ({
     address,
     signer: false,
     writable: false,
+    source: "lookupTable" as const,
+    ...(readonlyMap[i] != null && { lookupTableAddress: readonlyMap[i] }),
   }));
 
   return {

--- a/lib/solana/transaction/account-resolver.ts
+++ b/lib/solana/transaction/account-resolver.ts
@@ -136,6 +136,7 @@ export function selectAccountResolver(version: TransactionVersion): TransactionA
     case "legacy":
     case null:
     // SIMD-0385 v1 uses a flat address array with no ALTs — same resolution as legacy.
+    // falls through
     case 1:
       return resolveStaticAccounts;
     case 0:

--- a/lib/solana/transaction/build-payload.ts
+++ b/lib/solana/transaction/build-payload.ts
@@ -1,21 +1,5 @@
 import type { CompiledInstruction, TransactionPayloadContext, TransactionPayloadOutput } from "../types";
 
-// Solana message layout: [writable signers | readonly signers | writable non-signers | readonly non-signers]
-function buildAccounts(context: TransactionPayloadContext) {
-  const { accountKeys, numRequiredSignatures, numReadonlySignedAccounts, numReadonlyUnsignedAccounts } = context;
-
-  const readonlySignerStart = numRequiredSignatures - numReadonlySignedAccounts;
-  const readonlyUnsignedStart = accountKeys.length - numReadonlyUnsignedAccounts;
-
-  return accountKeys.map((address, i) => {
-    const signer = i < numRequiredSignatures;
-    const readonlySigned = signer && i >= readonlySignerStart;
-    const readonlyUnsigned = !signer && i >= readonlyUnsignedStart;
-    const writable = !readonlySigned && !readonlyUnsigned;
-    return { address, signer, writable };
-  });
-}
-
 function resolveAccountKey(index: number, accountKeys: string[]): string {
   const key = accountKeys[index];
   if (key === undefined) {
@@ -64,7 +48,7 @@ export function buildTransactionPayload(context: TransactionPayloadContext): Tra
     confirmation_status: context.confirmationStatus,
     confirmations: context.confirmations,
     log_messages: context.logMessages,
-    accounts: buildAccounts(context),
+    accounts: context.resolvedAccounts,
     instructions: buildInstructions(context),
   };
 

--- a/lib/solana/transaction/build-payload.ts
+++ b/lib/solana/transaction/build-payload.ts
@@ -1,0 +1,84 @@
+import type { CompiledInstruction, TransactionPayloadContext, TransactionPayloadOutput } from "../types";
+
+// Solana message layout: [writable signers | readonly signers | writable non-signers | readonly non-signers]
+function buildAccounts(context: TransactionPayloadContext) {
+  const { accountKeys, numRequiredSignatures, numReadonlySignedAccounts, numReadonlyUnsignedAccounts } = context;
+
+  const readonlySignerStart = numRequiredSignatures - numReadonlySignedAccounts;
+  const readonlyUnsignedStart = accountKeys.length - numReadonlyUnsignedAccounts;
+
+  return accountKeys.map((address, i) => {
+    const signer = i < numRequiredSignatures;
+    const readonlySigned = signer && i >= readonlySignerStart;
+    const readonlyUnsigned = !signer && i >= readonlyUnsignedStart;
+    const writable = !readonlySigned && !readonlyUnsigned;
+    return { address, signer, writable };
+  });
+}
+
+function resolveAccountKey(index: number, accountKeys: string[]): string {
+  const key = accountKeys[index];
+  if (key === undefined) {
+    throw new Error(`account index ${index} out of bounds for ${accountKeys.length} keys`);
+  }
+  return key;
+}
+
+function resolveInstruction(ix: CompiledInstruction, accountKeys: string[]) {
+  return {
+    program_id: resolveAccountKey(ix.programIdIndex, accountKeys),
+    accounts: ix.accounts.map(i => resolveAccountKey(i, accountKeys)),
+    data: ix.data,
+  };
+}
+
+function buildInstructions(context: TransactionPayloadContext) {
+  const { accountKeys, instructions, innerInstructions } = context;
+
+  const innerMap = new Map<number, readonly CompiledInstruction[]>();
+  for (const group of innerInstructions ?? []) {
+    const existing = innerMap.get(group.index);
+    innerMap.set(group.index, existing ? [...existing, ...group.instructions] : group.instructions);
+  }
+
+  return instructions.map((ix, i) => ({
+    ...resolveInstruction(ix, accountKeys),
+    inner_instructions: (innerMap.get(i) ?? []).map(inner => resolveInstruction(inner, accountKeys)),
+  }));
+}
+
+export function buildTransactionPayload(context: TransactionPayloadContext): TransactionPayloadOutput {
+  const safeSignerCount = Math.max(0, context.numRequiredSignatures);
+  const signers = context.accountKeys.slice(0, safeSignerCount);
+
+  const base = {
+    kind: "transaction" as const,
+    signature: context.signature,
+    slot: context.slot,
+    block_time: context.blockTime,
+    fee_lamports: context.feeLamports,
+    signers,
+    transaction_version: context.version,
+    recent_blockhash: context.recentBlockhash,
+    compute_units_consumed: context.computeUnitsConsumed,
+    confirmation_status: context.confirmationStatus,
+    confirmations: context.confirmations,
+    log_messages: context.logMessages,
+    accounts: buildAccounts(context),
+    instructions: buildInstructions(context),
+  };
+
+  switch (context.status) {
+    case "failed":
+      return {
+        entity: { ...base, status: context.status, error: context.err },
+      };
+    case "success":
+    case "unknown":
+      return { entity: { ...base, status: context.status, error: null } };
+    default: {
+      const _exhaustive: never = context;
+      throw new Error(`Unhandled transaction status: ${String((_exhaustive as TransactionPayloadContext).status)}`);
+    }
+  }
+}

--- a/lib/solana/transaction/normalizer.ts
+++ b/lib/solana/transaction/normalizer.ts
@@ -19,7 +19,12 @@ function toAccountKeyString(accountKey: string | { pubkey: string }): string {
   if (typeof accountKey === "string") {
     return accountKey;
   }
-  return accountKey.pubkey;
+  if (typeof accountKey?.pubkey === "string") {
+    return accountKey.pubkey;
+  }
+  throw new Error(
+    `Unexpected transaction probe: accountKey is not a string or {pubkey: string}: ${JSON.stringify(accountKey)}`,
+  );
 }
 
 function validateInstructionIndices(

--- a/lib/solana/transaction/normalizer.ts
+++ b/lib/solana/transaction/normalizer.ts
@@ -8,6 +8,7 @@ import type {
 } from "../types";
 import { asSafeNumeric } from "../parse-helpers";
 import { logger } from "../../observability/logger";
+import { selectAccountResolver } from "./account-resolver";
 
 function toAccountKeyString(accountKey: string | { pubkey: string }): string {
   if (typeof accountKey === "string") {
@@ -34,21 +35,19 @@ function validateInstructionIndices(
   }
 }
 
-function validateMessageIntegrity(
+function validateHeaderIntegrity(
   header: {
     numRequiredSignatures: number;
     numReadonlySignedAccounts: number;
     numReadonlyUnsignedAccounts: number;
   },
-  accountKeyCount: number,
-  instructions: readonly CompiledInstruction[],
-  innerInstructions: readonly CompiledInnerInstruction[] | null,
+  staticKeyCount: number,
 ): void {
   const { numRequiredSignatures, numReadonlySignedAccounts, numReadonlyUnsignedAccounts } = header;
 
-  if (numRequiredSignatures <= 0 || numRequiredSignatures > accountKeyCount) {
+  if (numRequiredSignatures <= 0 || numRequiredSignatures > staticKeyCount) {
     throw new Error(
-      `Unexpected transaction probe: numRequiredSignatures (${numRequiredSignatures}) out of range for ${accountKeyCount} account keys.`,
+      `Unexpected transaction probe: numRequiredSignatures (${numRequiredSignatures}) out of range for ${staticKeyCount} account keys.`,
     );
   }
 
@@ -60,14 +59,20 @@ function validateMessageIntegrity(
 
   if (
     numReadonlySignedAccounts >= numRequiredSignatures ||
-    numReadonlyUnsignedAccounts > accountKeyCount - numRequiredSignatures
+    numReadonlyUnsignedAccounts > staticKeyCount - numRequiredSignatures
   ) {
     throw new Error(
-      `Unexpected transaction probe: readonly counts (signed=${numReadonlySignedAccounts}, unsigned=${numReadonlyUnsignedAccounts}) exceed available accounts (signers=${numRequiredSignatures}, total=${accountKeyCount}).`,
+      `Unexpected transaction probe: readonly counts (signed=${numReadonlySignedAccounts}, unsigned=${numReadonlyUnsignedAccounts}) exceed available accounts (signers=${numRequiredSignatures}, total=${staticKeyCount}).`,
     );
   }
+}
 
-  validateInstructionIndices(instructions, accountKeyCount, "instruction");
+function validateInstructionIntegrity(
+  instructions: readonly CompiledInstruction[],
+  innerInstructions: readonly CompiledInnerInstruction[] | null,
+  totalKeyCount: number,
+): void {
+  validateInstructionIndices(instructions, totalKeyCount, "instruction");
 
   if (innerInstructions) {
     for (const group of innerInstructions) {
@@ -76,7 +81,7 @@ function validateMessageIntegrity(
           `Unexpected transaction probe: inner instruction group index (${group.index}) out of bounds for ${instructions.length} instructions.`,
         );
       }
-      validateInstructionIndices(group.instructions, accountKeyCount, "inner instruction");
+      validateInstructionIndices(group.instructions, totalKeyCount, "inner instruction");
     }
   }
 }
@@ -159,13 +164,23 @@ export function normalizeTransactionProbe(
   const meta = envelope.meta;
   const innerInstructions = meta?.innerInstructions ? Array.from(meta.innerInstructions) : null;
 
-  validateMessageIntegrity(header, accountKeys.length, instructions, innerInstructions);
+  const staticKeys = accountKeys.map(toAccountKeyString);
+  validateHeaderIntegrity(header, staticKeys.length);
+
+  const version = envelope.version ?? null;
+  const resolver = selectAccountResolver(version);
+  const { accountKeys: allKeys, resolvedAccounts } = resolver({
+    staticKeys,
+    header,
+    loadedAddresses: meta?.loadedAddresses,
+  });
+
+  validateInstructionIntegrity(instructions, innerInstructions, allKeys.length);
 
   const { numRequiredSignatures, numReadonlySignedAccounts, numReadonlyUnsignedAccounts } = header;
 
   const status = meta === null ? "unknown" : meta.err === null || meta.err === undefined ? "success" : "failed";
 
-  const version = envelope.version ?? null;
   const computeUnitsConsumed = meta ? asSafeNumeric(meta.computeUnitsConsumed ?? null) : null;
   const logMessages = meta?.logMessages ? Array.from(meta.logMessages) : null;
   const recentBlockhash = envelope.transaction.message.recentBlockhash ?? null;
@@ -177,7 +192,8 @@ export function normalizeTransactionProbe(
     slot,
     blockTime: asSafeNumeric(envelope.blockTime),
     feeLamports: meta ? asSafeNumeric(meta.fee) : null,
-    accountKeys: accountKeys.map(toAccountKeyString),
+    accountKeys: allKeys,
+    resolvedAccounts,
     numRequiredSignatures,
     version,
     computeUnitsConsumed,

--- a/lib/solana/transaction/normalizer.ts
+++ b/lib/solana/transaction/normalizer.ts
@@ -1,0 +1,207 @@
+import type {
+  CompiledInnerInstruction,
+  CompiledInstruction,
+  ConfirmationStatus,
+  SignatureStatusEnvelope,
+  TransactionPayloadContext,
+  TransactionProbeEnvelope,
+} from "../types";
+import { asSafeNumeric } from "../parse-helpers";
+import { logger } from "../../observability/logger";
+
+function toAccountKeyString(accountKey: string | { pubkey: string }): string {
+  if (typeof accountKey === "string") {
+    return accountKey;
+  }
+  return accountKey.pubkey;
+}
+
+function validateInstructionIndices(
+  instructions: readonly CompiledInstruction[],
+  accountKeyCount: number,
+  label: string,
+): void {
+  for (const ix of instructions) {
+    if (
+      ix.programIdIndex < 0 ||
+      ix.programIdIndex >= accountKeyCount ||
+      ix.accounts.some(idx => idx < 0 || idx >= accountKeyCount)
+    ) {
+      throw new Error(
+        `Unexpected transaction probe: ${label} index out of bounds (programIdIndex=${ix.programIdIndex}, accounts=[${ix.accounts.join(",")}], accountKeyCount=${accountKeyCount}).`,
+      );
+    }
+  }
+}
+
+function validateMessageIntegrity(
+  header: {
+    numRequiredSignatures: number;
+    numReadonlySignedAccounts: number;
+    numReadonlyUnsignedAccounts: number;
+  },
+  accountKeyCount: number,
+  instructions: readonly CompiledInstruction[],
+  innerInstructions: readonly CompiledInnerInstruction[] | null,
+): void {
+  const { numRequiredSignatures, numReadonlySignedAccounts, numReadonlyUnsignedAccounts } = header;
+
+  if (numRequiredSignatures <= 0 || numRequiredSignatures > accountKeyCount) {
+    throw new Error(
+      `Unexpected transaction probe: numRequiredSignatures (${numRequiredSignatures}) out of range for ${accountKeyCount} account keys.`,
+    );
+  }
+
+  if (numReadonlySignedAccounts < 0 || numReadonlyUnsignedAccounts < 0) {
+    throw new Error(
+      `Unexpected transaction probe: negative readonly account count (signed=${numReadonlySignedAccounts}, unsigned=${numReadonlyUnsignedAccounts}).`,
+    );
+  }
+
+  if (
+    numReadonlySignedAccounts >= numRequiredSignatures ||
+    numReadonlyUnsignedAccounts > accountKeyCount - numRequiredSignatures
+  ) {
+    throw new Error(
+      `Unexpected transaction probe: readonly counts (signed=${numReadonlySignedAccounts}, unsigned=${numReadonlyUnsignedAccounts}) exceed available accounts (signers=${numRequiredSignatures}, total=${accountKeyCount}).`,
+    );
+  }
+
+  validateInstructionIndices(instructions, accountKeyCount, "instruction");
+
+  if (innerInstructions) {
+    for (const group of innerInstructions) {
+      if (group.index < 0 || group.index >= instructions.length) {
+        throw new Error(
+          `Unexpected transaction probe: inner instruction group index (${group.index}) out of bounds for ${instructions.length} instructions.`,
+        );
+      }
+      validateInstructionIndices(group.instructions, accountKeyCount, "inner instruction");
+    }
+  }
+}
+
+function isKnownConfirmationStatus(value: string | null): value is ConfirmationStatus {
+  return value === "processed" || value === "confirmed" || value === "finalized";
+}
+
+function normalizeConfirmation(
+  signatureStatus: SignatureStatusEnvelope | null | undefined,
+  signature: string,
+): {
+  confirmationStatus: ConfirmationStatus | null;
+  confirmations: number | "max" | null;
+} {
+  const statusValue = signatureStatus?.value ?? null;
+  const rawStatus = statusValue?.confirmationStatus ?? null;
+  if (rawStatus !== null && !isKnownConfirmationStatus(rawStatus)) {
+    logger.warn({
+      event: "normalizer.unknown_confirmation_status",
+      value: rawStatus,
+      signature,
+    });
+  }
+  const confirmationStatus = isKnownConfirmationStatus(rawStatus) ? rawStatus : null;
+  const rawConfirmations = statusValue?.confirmations ?? null;
+  if (confirmationStatus === "finalized") {
+    return { confirmationStatus, confirmations: "max" };
+  }
+  if (typeof rawConfirmations === "bigint") {
+    // Confirmation count is bounded by MAX_LOCKOUT_HISTORY (32), safe to convert directly.
+    return { confirmationStatus, confirmations: Number(rawConfirmations) };
+  }
+  if (typeof rawConfirmations === "number") {
+    return { confirmationStatus, confirmations: rawConfirmations };
+  }
+  return { confirmationStatus, confirmations: null };
+}
+
+function normalizeTransactionError(
+  rawErr: unknown,
+  signature: string,
+): Record<string, unknown> | string | unknown[] | null {
+  if (rawErr === null || rawErr === undefined) {
+    return null;
+  }
+  if (typeof rawErr === "string") {
+    return rawErr;
+  }
+  if (Array.isArray(rawErr)) {
+    return rawErr as unknown[];
+  }
+  if (typeof rawErr === "object") {
+    return rawErr as Record<string, unknown>;
+  }
+  logger.warn({
+    event: "normalizer.unrecognized_err_shape",
+    value: String(rawErr),
+    signature,
+  });
+  return String(rawErr);
+}
+
+export function normalizeTransactionProbe(
+  signature: string,
+  envelope: TransactionProbeEnvelope,
+  signatureStatus?: SignatureStatusEnvelope | null,
+): TransactionPayloadContext | null {
+  if (envelope === null) {
+    return null;
+  }
+
+  const slot = asSafeNumeric(envelope.slot);
+  if (typeof slot !== "number") {
+    throw new Error("Unexpected transaction probe: slot is not a safe number.");
+  }
+
+  const { header, accountKeys } = envelope.transaction.message;
+  const instructions = Array.from(envelope.transaction.message.instructions ?? []);
+  const meta = envelope.meta;
+  const innerInstructions = meta?.innerInstructions ? Array.from(meta.innerInstructions) : null;
+
+  validateMessageIntegrity(header, accountKeys.length, instructions, innerInstructions);
+
+  const { numRequiredSignatures, numReadonlySignedAccounts, numReadonlyUnsignedAccounts } = header;
+
+  const status = meta === null ? "unknown" : meta.err === null || meta.err === undefined ? "success" : "failed";
+
+  const version = envelope.version ?? null;
+  const computeUnitsConsumed = meta ? asSafeNumeric(meta.computeUnitsConsumed ?? null) : null;
+  const logMessages = meta?.logMessages ? Array.from(meta.logMessages) : null;
+  const recentBlockhash = envelope.transaction.message.recentBlockhash ?? null;
+
+  const { confirmationStatus, confirmations } = normalizeConfirmation(signatureStatus, signature);
+
+  const base = {
+    signature,
+    slot,
+    blockTime: asSafeNumeric(envelope.blockTime),
+    feeLamports: meta ? asSafeNumeric(meta.fee) : null,
+    accountKeys: accountKeys.map(toAccountKeyString),
+    numRequiredSignatures,
+    version,
+    computeUnitsConsumed,
+    logMessages,
+    recentBlockhash,
+    numReadonlySignedAccounts,
+    numReadonlyUnsignedAccounts,
+    confirmationStatus,
+    confirmations,
+    instructions,
+    innerInstructions,
+  };
+
+  switch (status) {
+    case "failed": {
+      const err = normalizeTransactionError(meta?.err ?? null, signature);
+      return { ...base, status, err };
+    }
+    case "success":
+    case "unknown":
+      return { ...base, status, err: null };
+    default: {
+      const _exhaustive: never = status;
+      throw new Error(`Unhandled transaction status: ${String(_exhaustive)}`);
+    }
+  }
+}

--- a/lib/solana/transaction/normalizer.ts
+++ b/lib/solana/transaction/normalizer.ts
@@ -5,6 +5,7 @@ import type {
   SignatureStatusEnvelope,
   TransactionPayloadContext,
   TransactionProbeEnvelope,
+  TransactionVersion,
 } from "../types";
 import { asSafeNumeric } from "../parse-helpers";
 import { logger } from "../../observability/logger";
@@ -167,7 +168,8 @@ export function normalizeTransactionProbe(
   const staticKeys = accountKeys.map(toAccountKeyString);
   validateHeaderIntegrity(header, staticKeys.length);
 
-  const version = envelope.version ?? null;
+  const rawVersion = envelope.version ?? null;
+  const version = (typeof rawVersion === "bigint" ? Number(rawVersion) : rawVersion) as TransactionVersion;
   const resolver = selectAccountResolver(version);
   const { accountKeys: allKeys, resolvedAccounts } = resolver({
     staticKeys,

--- a/lib/solana/transaction/normalizer.ts
+++ b/lib/solana/transaction/normalizer.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import type {
   CompiledInnerInstruction,
   CompiledInstruction,
@@ -10,6 +12,8 @@ import type {
 import { asSafeNumeric } from "../parse-helpers";
 import { logger } from "../../observability/logger";
 import { selectAccountResolver } from "./account-resolver";
+
+const transactionVersionSchema = z.union([z.literal("legacy"), z.literal(0), z.literal(1), z.null()]);
 
 function toAccountKeyString(accountKey: string | { pubkey: string }): string {
   if (typeof accountKey === "string") {
@@ -169,7 +173,12 @@ export function normalizeTransactionProbe(
   validateHeaderIntegrity(header, staticKeys.length);
 
   const rawVersion = envelope.version ?? null;
-  const version = (typeof rawVersion === "bigint" ? Number(rawVersion) : rawVersion) as TransactionVersion;
+  const coerced = typeof rawVersion === "bigint" ? Number(rawVersion) : rawVersion;
+  const parsed = transactionVersionSchema.safeParse(coerced);
+  if (!parsed.success) {
+    throw new Error(`Unexpected transaction probe: unsupported version ${String(coerced)}.`);
+  }
+  const version: TransactionVersion = parsed.data;
   const resolver = selectAccountResolver(version);
   const { accountKeys: allKeys, resolvedAccounts } = resolver({
     staticKeys,

--- a/lib/solana/transaction/normalizer.ts
+++ b/lib/solana/transaction/normalizer.ts
@@ -173,6 +173,7 @@ export function normalizeTransactionProbe(
     staticKeys,
     header,
     loadedAddresses: meta?.loadedAddresses,
+    addressTableLookups: envelope.transaction.message.addressTableLookups,
   });
 
   validateInstructionIntegrity(instructions, innerInstructions, allKeys.length);

--- a/lib/solana/types.ts
+++ b/lib/solana/types.ts
@@ -64,16 +64,28 @@ export type CompiledInnerInstruction = {
   instructions: readonly CompiledInstruction[];
 };
 
+export type TransactionVersion = "legacy" | 0 | 1 | null;
+
+export type ResolvedAccount = {
+  address: string;
+  signer: boolean;
+  writable: boolean;
+};
+
 export type TransactionProbeEnvelope = {
   slot: number | bigint;
   blockTime: number | bigint | null;
-  version?: "legacy" | 0 | null;
+  version?: TransactionVersion;
   meta: {
     err: unknown;
     fee: number | bigint;
     computeUnitsConsumed?: number | bigint | null;
     logMessages?: readonly string[] | null;
     innerInstructions?: readonly CompiledInnerInstruction[] | null;
+    loadedAddresses?: {
+      readonly writable: readonly string[];
+      readonly readonly: readonly string[];
+    } | null;
   } | null;
   transaction: {
     message: {
@@ -217,13 +229,14 @@ type TransactionPayloadContextBase = {
   slot: number;
   blockTime: SafeNumeric;
   feeLamports: SafeNumeric;
-  version: "legacy" | 0 | null;
+  version: TransactionVersion;
   computeUnitsConsumed: SafeNumeric;
   logMessages: readonly string[] | null;
   recentBlockhash: string | null;
   confirmationStatus: ConfirmationStatus | null;
   confirmations: number | "max" | null;
   accountKeys: string[];
+  resolvedAccounts: ResolvedAccount[];
   numRequiredSignatures: number;
   numReadonlySignedAccounts: number;
   numReadonlyUnsignedAccounts: number;
@@ -247,7 +260,7 @@ type TransactionPayloadEntityBase = {
   block_time: SafeNumeric;
   fee_lamports: SafeNumeric;
   signers: string[];
-  transaction_version: "legacy" | 0 | null;
+  transaction_version: TransactionVersion;
   recent_blockhash: string | null;
   compute_units_consumed: SafeNumeric;
   confirmation_status: ConfirmationStatus | null;

--- a/lib/solana/types.ts
+++ b/lib/solana/types.ts
@@ -72,10 +72,9 @@ export type AccountRole = {
   writable: boolean;
 };
 
-export type ResolvedAccount = AccountRole & {
-  source: "static" | "lookupTable";
-  lookupTableAddress?: string;
-};
+export type ResolvedAccount =
+  | (AccountRole & { source: "static" })
+  | (AccountRole & { source: "lookupTable"; lookupTableAddress?: string });
 
 export type AddressTableLookup = {
   accountKey: string;
@@ -248,7 +247,9 @@ type TransactionPayloadContextBase = {
   recentBlockhash: string | null;
   confirmationStatus: ConfirmationStatus | null;
   confirmations: number | "max" | null;
+  /** All account keys in instruction-index order (static + loaded for v0). */
   accountKeys: string[];
+  /** Parallel to accountKeys — resolvedAccounts[i].address === accountKeys[i]. */
   resolvedAccounts: ResolvedAccount[];
   numRequiredSignatures: number;
   numReadonlySignedAccounts: number;

--- a/lib/solana/types.ts
+++ b/lib/solana/types.ts
@@ -86,7 +86,8 @@ export type AddressTableLookup = {
 export type TransactionProbeEnvelope = {
   slot: number | bigint;
   blockTime: number | bigint | null;
-  version?: TransactionVersion;
+  /** @solana/kit returns version as bigint (0n) or "legacy". Normalized to TransactionVersion by the normalizer. */
+  version?: "legacy" | bigint | null;
   meta: {
     err: unknown;
     fee: number | bigint;

--- a/lib/solana/types.ts
+++ b/lib/solana/types.ts
@@ -66,10 +66,21 @@ export type CompiledInnerInstruction = {
 
 export type TransactionVersion = "legacy" | 0 | 1 | null;
 
-export type ResolvedAccount = {
+export type AccountRole = {
   address: string;
   signer: boolean;
   writable: boolean;
+};
+
+export type ResolvedAccount = AccountRole & {
+  source: "static" | "lookupTable";
+  lookupTableAddress?: string;
+};
+
+export type AddressTableLookup = {
+  accountKey: string;
+  writableIndexes: readonly number[];
+  readonlyIndexes: readonly number[];
 };
 
 export type TransactionProbeEnvelope = {
@@ -97,6 +108,7 @@ export type TransactionProbeEnvelope = {
       accountKeys: readonly (string | { pubkey: string })[];
       recentBlockhash?: string;
       instructions: readonly CompiledInstruction[];
+      addressTableLookups?: readonly AddressTableLookup[];
     };
   };
 } | null;
@@ -266,11 +278,7 @@ type TransactionPayloadEntityBase = {
   confirmation_status: ConfirmationStatus | null;
   confirmations: number | "max" | null;
   log_messages: readonly string[] | null;
-  accounts: {
-    address: string;
-    signer: boolean;
-    writable: boolean;
-  }[];
+  accounts: ResolvedAccount[];
   instructions: {
     program_id: string;
     accounts: string[];

--- a/lib/solana/types.ts
+++ b/lib/solana/types.ts
@@ -1,4 +1,4 @@
-import type { MetaplexMetadataResult } from "./metaplex-metadata";
+import type { MetaplexMetadataResult } from "./resolvers/metaplex-metadata";
 export type { MetaplexMetadataResult };
 
 // Inlined from resolvers/security-txt-parser.ts (ported in Step 5)

--- a/lib/tools/inspectEntityTools.ts
+++ b/lib/tools/inspectEntityTools.ts
@@ -18,10 +18,8 @@ const INSPECT_ENTITY_DESCRIPTION = [
   '- "stake", "vote", "nonce", "sysvar", "config", "address-lookup-table", "feature", "nftoken", "solana-attestation-service": Recognized system account types.',
   '- "unknown": Unrecognized account type.',
   "",
-  "NOTE: Transaction inspection is not yet supported and will be added in a future update. Currently only account addresses are resolved.",
-  // FIXME(@rogaldh): Replace with full TRANSACTION DATA description once resolveTransaction is implemented (Step 5):
-  // "TRANSACTION DATA (entity.kind = transaction):",
-  // 'signature, slot, block time, status (success/failed/unknown), fee in lamports, ordered signer list, transaction version, recent blockhash, compute units consumed, confirmation status and confirmations (numeric count or "max" when finalized), error detail (when failed), program log messages, accounts with signer/writable roles, instructions with resolved program addresses and nested CPI (inner instructions). Numeric fields that exceed safe integer range are returned as decimal strings.',
+  "TRANSACTION DATA (entity.kind = transaction):",
+  'signature, slot, block time, status (success/failed/unknown), fee in lamports, ordered signer list, transaction version, recent blockhash, compute units consumed, confirmation status and confirmations (numeric count or "max" when finalized), error detail (when failed), program log messages, accounts with signer/writable roles, instructions with resolved program addresses and nested CPI (inner instructions). Numeric fields that exceed safe integer range are returned as decimal strings.',
   "",
   "OUTPUT: Responses use { payload: { entity: { kind, ...fields } }, errors: [] }. Unresolvable fields return explicit unknown markers instead of being silently omitted.",
 ].join("\n");

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "audit:security": "pnpm audit --audit-level=high",
     "build": "tsup",
     "dev:local": "vercel dev --local",
+    "dev:mcp": "tsx api/start.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "inspector": "npx -y @modelcontextprotocol/inspector npx mcp-remote http://localhost:3000/mcp",

--- a/package.json
+++ b/package.json
@@ -2,32 +2,28 @@
   "name": "solana-mcp",
   "version": "1.0.0",
   "description": "",
+  "keywords": [],
+  "license": "ISC",
+  "author": "",
   "main": "index.js",
   "scripts": {
-    "start": "vercel dev",
-    "dev:local": "vercel dev --local",
+    "audit:security": "pnpm audit --audit-level=high",
     "build": "tsup",
-    "start:app": "node dist/start.js",
-    "test": "pnpm test:integration",
-    "test:integration": "vitest run tests/integration.test.ts tests/unit/",
-    "test:e2e": "vitest run tests/e2e.test.ts",
-    "test:coverage": "vitest run --coverage",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "dev:local": "vercel dev --local",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "inspector": "npx -y @modelcontextprotocol/inspector npx mcp-remote http://localhost:3000/mcp",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "start": "vercel dev",
+    "start:app": "node dist/start.js",
+    "test": "pnpm test:integration",
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "vitest run tests/e2e.test.ts",
+    "test:integration": "vitest run tests/integration.test.ts tests/unit/",
     "typecheck": "pnpm typecheck:ts && pnpm typecheck:vitest",
     "typecheck:ts": "tsc --noEmit",
-    "typecheck:vitest": "vitest --run --typecheck.only",
-    "inspector": "npx -y @modelcontextprotocol/inspector npx mcp-remote http://localhost:3000/mcp",
-    "audit:security": "pnpm audit --audit-level=high"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "packageManager": "pnpm@10.30.0",
-  "engines": {
-    "node": "24.x"
+    "typecheck:vitest": "vitest --run --typecheck.only"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.52",
@@ -74,5 +70,9 @@
     "typescript-eslint": "^8.57.2",
     "vercel": "^52.0.0",
     "vitest": "^4.1.3"
+  },
+  "packageManager": "pnpm@10.30.0",
+  "engines": {
+    "node": "24.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.52",
+    "@coral-xyz/anchor": "^0.32.1",
     "@duneanalytics/client-sdk": "^0.3.5",
     "@inkeep/inkeep-analytics": "0.2.4-alpha.36",
     "@metaplex-foundation/mpl-token-metadata": "^3.4.0",
@@ -39,6 +40,7 @@
     "@noble/hashes": "^2.0.1",
     "@solana-program/address-lookup-table": "^0.11.0",
     "@solana-program/loader-v3": "^0.3.0",
+    "@solana-program/program-metadata": "^0.5.1",
     "@solana-program/stake": "^0.6.0",
     "@solana-program/token": "^0.13.0",
     "@solana-program/token-2022": "^0.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2247,6 +2247,9 @@ packages:
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
   '@types/qs@6.15.0':
     resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
 
@@ -6180,6 +6183,12 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 25.6.0
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
 
   '@types/qs@6.15.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,15 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.52
         version: 3.0.53(zod@4.3.6)
+      '@coral-xyz/anchor':
+        specifier: ^0.32.1
+        version: 0.32.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@duneanalytics/client-sdk':
         specifier: ^0.3.5
         version: 0.3.5
       '@inkeep/inkeep-analytics':
         specifier: 0.2.4-alpha.36
-        version: 0.2.4-alpha.36(react@19.2.4)
+        version: 0.2.4-alpha.36(react-dom@19.2.5(react@19.2.4))(react@19.2.4)
       '@metaplex-foundation/mpl-token-metadata':
         specifier: ^3.4.0
         version: 3.4.0(@metaplex-foundation/umi@1.5.1)
@@ -31,7 +34,7 @@ importers:
         version: 1.29.0(zod@4.3.6)
       '@neondatabase/serverless':
         specifier: ^1.0.2
-        version: 1.1.0
+        version: 1.0.2
       '@noble/hashes':
         specifier: ^2.0.1
         version: 2.2.0
@@ -41,6 +44,9 @@ importers:
       '@solana-program/loader-v3':
         specifier: ^0.3.0
         version: 0.3.0(@solana/kit@6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana-program/program-metadata':
+        specifier: ^0.5.1
+        version: 0.5.1(@solana/kit@6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
       '@solana-program/stake':
         specifier: ^0.6.0
         version: 0.6.0(@solana/kit@6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
@@ -58,7 +64,7 @@ importers:
         version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       ai:
         specifier: ^6.0.154
-        version: 6.0.168(zod@4.3.6)
+        version: 6.0.161(zod@4.3.6)
       bs58:
         specifier: ^6.0.0
         version: 6.0.0
@@ -76,7 +82,7 @@ importers:
         version: 2.16.11
       mcp-handler:
         specifier: 1.1.0
-        version: 1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
+        version: 1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(next@16.2.4(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.4))(react@19.2.4))
       raw-body:
         specifier: ^3.0.0
         version: 3.0.2
@@ -89,7 +95,7 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.2.1)
+        version: 10.0.1(eslint@10.2.0)
       '@solana/prettier-config-solana':
         specifier: ^0.0.6
         version: 0.0.6(prettier@3.8.3)
@@ -98,39 +104,39 @@ importers:
         version: 25.6.0
       '@vitest/coverage-v8':
         specifier: ^4.1.3
-        version: 4.1.5(vitest@4.1.5)
+        version: 4.1.4(vitest@4.1.4)
       eslint:
         specifier: ^10.1.0
-        version: 10.2.1
+        version: 10.2.0
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.2.1)
+        version: 10.1.8(eslint@10.2.0)
       eslint-plugin-prettier:
         specifier: ^5.5.5
-        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@10.2.1))(eslint@10.2.1)(prettier@3.8.3)
+        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@10.2.0))(eslint@10.2.0)(prettier@3.8.3)
       prettier:
         specifier: ^3.8.1
         version: 3.8.3
       tsup:
         specifier: ^8.5.0
-        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.57.2
-        version: 8.59.0(eslint@10.2.1)(typescript@5.9.3)
+        version: 8.58.2(eslint@10.2.0)(typescript@5.9.3)
       vercel:
         specifier: ^52.0.0
-        version: 52.0.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.2)(typescript@5.9.3)
+        version: 52.0.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.3
-        version: 4.1.5(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
-  '@ai-sdk/gateway@3.0.104':
-    resolution: {integrity: sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==}
+  '@ai-sdk/gateway@3.0.98':
+    resolution: {integrity: sha512-Ol+nP8PIlj8FjN8qKlxhE89N0woqAaGi9CUBGp1boe3RafpphJ7WMuq/RErSvxtwTqje03TP+zIdzP113krxRg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -178,6 +184,20 @@ packages:
 
   '@bytecodealliance/preview2-shim@0.17.6':
     resolution: {integrity: sha512-n3cM88gTen5980UOBAD6xDcNNL3ocTK8keab21bpx1ONdA+ARj7uD1qoFxOWCyKlkpSi195FH+GeAut7Oc6zZw==}
+
+  '@coral-xyz/anchor-errors@0.31.1':
+    resolution: {integrity: sha512-NhNEku4F3zzUSBtrYz84FzYWm48+9OvmT1Hhnwr6GnPQry2dsEqH/ti/7ASjjpoFTWRnPXrjAIT1qM6Isop+LQ==}
+    engines: {node: '>=10'}
+
+  '@coral-xyz/anchor@0.32.1':
+    resolution: {integrity: sha512-zAyxFtfeje2FbMA1wzgcdVs7Hng/MijPKpRijoySPCicnvcTQs/+dnPZ/cR+LcXM9v9UYSyW81uRNYZtN5G4yg==}
+    engines: {node: '>=17'}
+
+  '@coral-xyz/borsh@0.31.1':
+    resolution: {integrity: sha512-9N8AU9F0ubriKfNE3g1WF0/4dtlGXoBN/hd1PvbNBamBNwRgHxH4P+o3Zt7rSEloW1HUs6LfZEchlx9fW7POYw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@solana/web3.js': ^1.69.0
 
   '@duneanalytics/client-sdk@0.3.5':
     resolution: {integrity: sha512-4YcET+PsKdGbEZi39HMqB5in8FzOVClmSu8lTJSPsKj5gfIgKNwRbBMVnhLvX3xiChXRse2vWGqMPWeLl0zjEQ==}
@@ -728,16 +748,12 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@humanfs/core@0.19.2':
-    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
 
-  '@humanfs/node@0.16.8':
-    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
-    engines: {node: '>=18.18.0'}
-
-  '@humanfs/types@0.15.0':
-    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
     engines: {node: '>=18.18.0'}
 
   '@humanwhocodes/module-importer@1.0.1':
@@ -747,6 +763,162 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@inkeep/inkeep-analytics@0.2.4-alpha.36':
     resolution: {integrity: sha512-L1Ei2rTUsvaKoXiGKbisl2ck6ZB5J3hlXM9GIwtlfgCMWUbqRn7Xs0xB4/6cyq7NrHQ4bMCTulmdw3PjqN/FHA==}
@@ -889,15 +1061,70 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+  '@napi-rs/wasm-runtime@1.1.3':
+    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@neondatabase/serverless@1.1.0':
-    resolution: {integrity: sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==}
+  '@neondatabase/serverless@1.0.2':
+    resolution: {integrity: sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==}
     engines: {node: '>=19.0.0'}
+
+  '@next/env@16.2.4':
+    resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
+
+  '@next/swc-darwin-arm64@16.2.4':
+    resolution: {integrity: sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@16.2.4':
+    resolution: {integrity: sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@16.2.4':
+    resolution: {integrity: sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@16.2.4':
+    resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@16.2.4':
+    resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@16.2.4':
+    resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@16.2.4':
+    resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.2.4':
+    resolution: {integrity: sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
 
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
@@ -1228,8 +1455,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm-eabi@4.60.2':
-    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
     cpu: [arm]
     os: [android]
 
@@ -1238,8 +1465,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.60.2':
-    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+  '@rollup/rollup-android-arm64@4.60.1':
+    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
     cpu: [arm64]
     os: [android]
 
@@ -1248,8 +1475,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-arm64@4.60.2':
-    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
     cpu: [arm64]
     os: [darwin]
 
@@ -1258,8 +1485,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.60.2':
-    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+  '@rollup/rollup-darwin-x64@4.60.1':
+    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
     cpu: [x64]
     os: [darwin]
 
@@ -1268,8 +1495,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-arm64@4.60.2':
-    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
     cpu: [arm64]
     os: [freebsd]
 
@@ -1278,8 +1505,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.60.2':
-    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
     cpu: [x64]
     os: [freebsd]
 
@@ -1289,8 +1516,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
-    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -1301,8 +1528,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
-    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
@@ -1313,8 +1540,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.2':
-    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -1325,8 +1552,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-musl@4.60.2':
-    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
@@ -1337,8 +1564,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.2':
-    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
@@ -1349,8 +1576,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-musl@4.60.2':
-    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
     libc: [musl]
@@ -1361,8 +1588,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
-    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -1373,8 +1600,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.2':
-    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
@@ -1385,8 +1612,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
-    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -1397,8 +1624,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.2':
-    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
@@ -1409,8 +1636,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.2':
-    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -1421,8 +1648,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.60.2':
-    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -1433,8 +1660,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-x64-musl@4.60.2':
-    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -1444,8 +1671,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openbsd-x64@4.60.2':
-    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
     cpu: [x64]
     os: [openbsd]
 
@@ -1454,8 +1681,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-openharmony-arm64@4.60.2':
-    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
     cpu: [arm64]
     os: [openharmony]
 
@@ -1464,8 +1691,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.2':
-    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
     cpu: [arm64]
     os: [win32]
 
@@ -1474,8 +1701,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.2':
-    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
     cpu: [ia32]
     os: [win32]
 
@@ -1484,8 +1711,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.60.2':
-    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
     cpu: [x64]
     os: [win32]
 
@@ -1494,8 +1721,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.60.2':
-    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
     cpu: [x64]
     os: [win32]
 
@@ -1507,8 +1734,19 @@ packages:
     peerDependencies:
       '@solana/kit': ^6.0
 
+  '@solana-program/compute-budget@0.13.0':
+    resolution: {integrity: sha512-jdiiWaxFG3kEf6bYPNo2mwz2jNxaj7sF+gZIb8wHw9zK3ZILmpkg4sUeChb1BnH2UGf+HgYb9L/lMdqOTqUoWA==}
+    peerDependencies:
+      '@solana/kit': ^6.0.0
+
   '@solana-program/loader-v3@0.3.0':
     resolution: {integrity: sha512-xEMQ+JOTKCInROozoTmHJk+atFxYSuLQ+KevKxpib+2uZzXV/Z58LqF9nYLKQpZMi8sk06CUeSsa9N0Hdiha1g==}
+    peerDependencies:
+      '@solana/kit': ^6.0.0
+
+  '@solana-program/program-metadata@0.5.1':
+    resolution: {integrity: sha512-KORPOJI4+/kdL5BsSub4cU/F84dhM9tEl74J4t+OvobCHcE4SqpPBHFG4VoR/5eRUWr59MfdeTzlFVdYJiCNhw==}
+    hasBin: true
     peerDependencies:
       '@solana/kit': ^6.0.0
 
@@ -1516,6 +1754,11 @@ packages:
     resolution: {integrity: sha512-s2b2s1OUevNpPW4qkI2gbasdTnojGAt6mMqyoLzjycIpAqx68meSH+QTkHCGHAPDnmNACE81iz0qxTYZ9lxKkw==}
     peerDependencies:
       '@solana/kit': ^6.0
+
+  '@solana-program/system@0.11.0':
+    resolution: {integrity: sha512-SJeQVTkqGZzIXd7XHlCxnfpKpvPZghB1IFwddPPG04ydVXtDLRWp9wLoTR5Prkl9FIWRe/c5VgT4nxyzW1cAuQ==}
+    peerDependencies:
+      '@solana/kit': ^6.0.0
 
   '@solana-program/system@0.12.0':
     resolution: {integrity: sha512-ZnAAWeGVMWNtJhw3GdifI2HnhZ0A0H0qs8tBkcFvxp/8wIavvO+GOM4Jd0N22u2+Lni2zcwvcrxrsxj6Mjphng==}
@@ -1940,6 +2183,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
   '@swc/helpers@0.5.20':
     resolution: {integrity: sha512-2egEBHUMasdypIzrprsu8g+OEVd7Vp2MM3a2eVlM/cyFYto0nGz5BX5BTgh/ShZZI9ed+ozEq+Ngt+rgmUs8tw==}
 
@@ -1980,8 +2226,14 @@ packages:
   '@types/node@20.11.0':
     resolution: {integrity: sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==}
 
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
@@ -1992,63 +2244,63 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@typescript-eslint/eslint-plugin@8.59.0':
-    resolution: {integrity: sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==}
+  '@typescript-eslint/eslint-plugin@8.58.2':
+    resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.59.0
+      '@typescript-eslint/parser': ^8.58.2
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.59.0':
-    resolution: {integrity: sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.59.0':
-    resolution: {integrity: sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.59.0':
-    resolution: {integrity: sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.59.0':
-    resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.59.0':
-    resolution: {integrity: sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==}
+  '@typescript-eslint/parser@8.58.2':
+    resolution: {integrity: sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.59.0':
-    resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.59.0':
-    resolution: {integrity: sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==}
+  '@typescript-eslint/project-service@8.58.2':
+    resolution: {integrity: sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.59.0':
-    resolution: {integrity: sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==}
+  '@typescript-eslint/scope-manager@8.58.2':
+    resolution: {integrity: sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.58.2':
+    resolution: {integrity: sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.58.2':
+    resolution: {integrity: sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.59.0':
-    resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
+  '@typescript-eslint/types@8.58.2':
+    resolution: {integrity: sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.58.2':
+    resolution: {integrity: sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.58.2':
+    resolution: {integrity: sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.58.2':
+    resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vercel/backends@0.2.0':
@@ -2124,6 +2376,10 @@ packages:
   '@vercel/node@5.7.13':
     resolution: {integrity: sha512-IbGplZ0lAvk6D4scBENKRLOjVbLa3knA3nDJL/1tmcy32UeWRdumo/YpoNMYo3Eg6y6uLtI1ajwpnQJsfzUtjg==}
 
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
+
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
@@ -2158,20 +2414,20 @@ packages:
   '@vercel/static-config@3.2.0':
     resolution: {integrity: sha512-UpOEIgWxWx0M+mDe1IMdHS6JuWM/L5nNIJ4ixX8v9JgBAejymo88OkgnmfLCNMem0Wd+b5vcQPWLdZybCndlsA==}
 
-  '@vitest/coverage-v8@4.1.5':
-    resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
+  '@vitest/coverage-v8@4.1.4':
+    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
     peerDependencies:
-      '@vitest/browser': 4.1.5
-      vitest: 4.1.5
+      '@vitest/browser': 4.1.4
+      vitest: 4.1.4
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.5':
-    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
 
-  '@vitest/mocker@4.1.5':
-    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2181,20 +2437,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.5':
-    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
-  '@vitest/runner@4.1.5':
-    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
 
-  '@vitest/snapshot@4.1.5':
-    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
-  '@vitest/spy@4.1.5':
-    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
-  '@vitest/utils@4.1.5':
-    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   '@yarnpkg/parsers@3.0.3':
     resolution: {integrity: sha512-mQZgUSgFurUtA07ceMjxrWkYz8QtDuYkvPlu0ZqncgjopQ0t6CNEo/OSealkmnagSUx8ZD5ewvezUwUuMqutQg==}
@@ -2231,8 +2487,8 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
-  ai@6.0.168:
-    resolution: {integrity: sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==}
+  ai@6.0.161:
+    resolution: {integrity: sha512-ufhmijmx2YyWTPAicGgtpLOB/xD7mG8zKs1pT1Trj+JL/3r1rS8fkMi/cHZoChSAQSGB4pgmcWVxDrVTUvK2IQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2329,8 +2585,13 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  basic-ftp@5.3.0:
-    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
+  baseline-browser-mapping@2.10.20:
+    resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  basic-ftp@5.2.2:
+    resolution: {integrity: sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==}
     engines: {node: '>=10.0.0'}
 
   bindings@1.5.0:
@@ -2366,6 +2627,10 @@ packages:
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
+  buffer-layout@1.2.2:
+    resolution: {integrity: sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==}
+    engines: {node: '>=4.5'}
+
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
@@ -2399,6 +2664,13 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  caniuse-lite@1.0.30001788:
+    resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -2422,6 +2694,9 @@ packages:
   cjs-module-lexer@1.2.3:
     resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
 
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
@@ -2436,6 +2711,10 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -2491,6 +2770,9 @@ packages:
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
+
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2661,8 +2943,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.2.1:
-    resolution: {integrity: sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==}
+  eslint@10.2.0:
+    resolution: {integrity: sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -2706,6 +2988,9 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -2717,10 +3002,6 @@ packages:
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
-    engines: {node: '>=18.0.0'}
-
-  eventsource-parser@3.0.8:
-    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -2915,8 +3196,8 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.3:
-    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
   hono@4.12.12:
@@ -3083,8 +3364,8 @@ packages:
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
-  jsonfile@6.2.1:
-    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+  jsonfile@6.2.0:
+    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
   jsonlines@0.1.1:
     resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
@@ -3258,6 +3539,27 @@ packages:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
     engines: {node: '>= 0.4.0'}
 
+  next@16.2.4:
+    resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -3355,6 +3657,9 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
   parse-ms@2.1.0:
     resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
     engines: {node: '>=6'}
@@ -3400,6 +3705,17 @@ packages:
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
@@ -3443,9 +3759,29 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -3504,6 +3840,11 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -3552,8 +3893,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rollup@4.60.2:
-    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+  rollup@4.60.1:
+    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -3576,6 +3917,9 @@ packages:
   sandbox@2.5.6:
     resolution: {integrity: sha512-tnFr7nyiuEhsAGb+xy60SDbij0790X+FgDljh3J/2HaRM6yQgNJkQKHbDH8ld7mR+PozXGgEfJ2Dc/5OyFnwsg==}
     hasBin: true
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3604,6 +3948,10 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3689,8 +4037,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@4.1.0:
-    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   stream-chain@2.2.5:
     resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
@@ -3711,10 +4059,26 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  superstruct@0.15.5:
+    resolution: {integrity: sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==}
 
   superstruct@2.0.2:
     resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
@@ -3795,6 +4159,9 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  toml@3.0.0:
+    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -3852,8 +4219,8 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typescript-eslint@8.59.0:
-    resolution: {integrity: sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==}
+  typescript-eslint@8.58.2:
+    resolution: {integrity: sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -3872,6 +4239,9 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
@@ -3963,20 +4333,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.5:
-    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.5
-      '@vitest/browser-preview': 4.1.5
-      '@vitest/browser-webdriverio': 4.1.5
-      '@vitest/coverage-istanbul': 4.1.5
-      '@vitest/coverage-v8': 4.1.5
-      '@vitest/ui': 4.1.5
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -4062,6 +4432,10 @@ packages:
     resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
     engines: {node: '>= 6.0'}
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
@@ -4105,11 +4479,11 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@3.0.104(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.98(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
-      '@vercel/oidc': 3.2.0
+      '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
   '@ai-sdk/openai@3.0.53(zod@4.3.6)':
@@ -4122,7 +4496,7 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.8
+      eventsource-parser: 3.0.6
       zod: 4.3.6
 
   '@ai-sdk/provider@3.0.8':
@@ -4147,6 +4521,35 @@ snapshots:
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@bytecodealliance/preview2-shim@0.17.6': {}
+
+  '@coral-xyz/anchor-errors@0.31.1': {}
+
+  '@coral-xyz/anchor@0.32.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@coral-xyz/anchor-errors': 0.31.1
+      '@coral-xyz/borsh': 0.31.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@noble/hashes': 1.8.0
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.3
+      bs58: 4.0.1
+      buffer-layout: 1.2.2
+      camelcase: 6.3.0
+      cross-fetch: 3.2.0
+      eventemitter3: 4.0.7
+      pako: 2.1.0
+      superstruct: 0.15.5
+      toml: 3.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@coral-xyz/borsh@0.31.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.3
+      buffer-layout: 1.2.2
 
   '@duneanalytics/client-sdk@0.3.5':
     dependencies:
@@ -4414,9 +4817,9 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.1)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.2.0)':
     dependencies:
-      eslint: 10.2.1
+      eslint: 10.2.0
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -4437,9 +4840,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.2.1)':
+  '@eslint/js@10.0.1(eslint@10.2.0)':
     optionalDependencies:
-      eslint: 10.2.1
+      eslint: 10.2.0
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -4454,28 +4857,123 @@ snapshots:
     dependencies:
       hono: 4.12.12
 
-  '@humanfs/core@0.19.2':
-    dependencies:
-      '@humanfs/types': 0.15.0
+  '@humanfs/core@0.19.1': {}
 
-  '@humanfs/node@0.16.8':
+  '@humanfs/node@0.16.7':
     dependencies:
-      '@humanfs/core': 0.19.2
-      '@humanfs/types': 0.15.0
+      '@humanfs/core': 0.19.1
       '@humanwhocodes/retry': 0.4.3
-
-  '@humanfs/types@0.15.0': {}
 
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inkeep/inkeep-analytics@0.2.4-alpha.36(react@19.2.4)':
+  '@iarna/toml@2.2.5': {}
+
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.9.1
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@inkeep/inkeep-analytics@0.2.4-alpha.36(react-dom@19.2.5(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
       react: 19.2.4
+      react-dom: 19.2.5(react@19.2.4)
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
@@ -4642,14 +5140,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
     dependencies:
       '@emnapi/core': 1.9.1
       '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@neondatabase/serverless@1.1.0': {}
+  '@neondatabase/serverless@1.0.2':
+    dependencies:
+      '@types/node': 22.19.17
+      '@types/pg': 8.20.0
+
+  '@next/env@16.2.4':
+    optional: true
+
+  '@next/swc-darwin-arm64@16.2.4':
+    optional: true
+
+  '@next/swc-darwin-x64@16.2.4':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.2.4':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.2.4':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.2.4':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.2.4':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@16.2.4':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.2.4':
+    optional: true
 
   '@noble/curves@1.9.7':
     dependencies:
@@ -4725,7 +5253,7 @@ snapshots:
 
   '@oxc-transform/binding-wasm32-wasi@0.111.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -4824,7 +5352,7 @@ snapshots:
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.1(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -4838,162 +5366,162 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.1': {}
 
-  '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
+  '@rollup/pluginutils@5.3.0(rollup@4.60.1)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
-      rollup: 4.60.2
+      rollup: 4.60.1
 
   '@rollup/rollup-android-arm-eabi@4.60.0':
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.60.2':
+  '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
 
   '@rollup/rollup-android-arm64@4.60.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.60.2':
+  '@rollup/rollup-android-arm64@4.60.1':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.60.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.60.2':
+  '@rollup/rollup-darwin-arm64@4.60.1':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.60.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.60.2':
+  '@rollup/rollup-darwin-x64@4.60.1':
     optional: true
 
   '@rollup/rollup-freebsd-arm64@4.60.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.60.2':
+  '@rollup/rollup-freebsd-arm64@4.60.1':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.60.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.60.2':
+  '@rollup/rollup-freebsd-x64@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.60.2':
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.60.2':
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.60.2':
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.60.2':
+  '@rollup/rollup-linux-x64-musl@4.60.1':
     optional: true
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.60.2':
+  '@rollup/rollup-openbsd-x64@4.60.1':
     optional: true
 
   '@rollup/rollup-openharmony-arm64@4.60.0':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.60.2':
+  '@rollup/rollup-openharmony-arm64@4.60.1':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.60.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.60.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
     optional: true
 
   '@rollup/rollup-win32-x64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.60.2':
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.60.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.60.2':
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
   '@sinclair/typebox@0.25.24': {}
@@ -5002,11 +5530,30 @@ snapshots:
     dependencies:
       '@solana/kit': 6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
+  '@solana-program/compute-budget@0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+
   '@solana-program/loader-v3@0.3.0(@solana/kit@6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/kit': 6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
+  '@solana-program/program-metadata@0.5.1(@solana/kit@6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@iarna/toml': 2.2.5
+      '@solana-program/compute-budget': 0.13.0(@solana/kit@6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana-program/system': 0.11.0(@solana/kit@6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      commander: 13.1.0
+      pako: 2.1.0
+      picocolors: 1.1.1
+      yaml: 2.8.3
+
   '@solana-program/stake@0.6.0(@solana/kit@6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/kit': 6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+
+  '@solana-program/system@0.11.0(@solana/kit@6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))':
     dependencies:
       '@solana/kit': 6.8.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
 
@@ -5534,6 +6081,11 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@swc/helpers@0.5.20':
     dependencies:
       tslib: 2.8.1
@@ -5577,9 +6129,19 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 25.6.0
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
 
   '@types/uuid@10.0.0': {}
 
@@ -5591,15 +6153,15 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
-  '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@5.9.3))(eslint@10.2.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.59.0
-      '@typescript-eslint/type-utils': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.59.0
-      eslint: 10.2.1
+      '@typescript-eslint/parser': 8.58.2(eslint@10.2.0)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.58.2
+      '@typescript-eslint/type-utils': 8.58.2(eslint@10.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@10.2.0)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.58.2
+      eslint: 10.2.0
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -5607,56 +6169,56 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.58.2(eslint@10.2.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.59.0
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.59.0
+      '@typescript-eslint/scope-manager': 8.58.2
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3
-      eslint: 10.2.1
+      eslint: 10.2.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.59.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.58.2(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.2
       debug: 4.4.3
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.59.0':
+  '@typescript-eslint/scope-manager@8.58.2':
     dependencies:
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/visitor-keys': 8.59.0
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/visitor-keys': 8.58.2
 
-  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.58.2(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.59.0(eslint@10.2.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.58.2(eslint@10.2.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@10.2.0)(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 10.2.1
+      eslint: 10.2.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.59.0': {}
+  '@typescript-eslint/types@8.58.2': {}
 
-  '@typescript-eslint/typescript-estree@8.59.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.58.2(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.59.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/visitor-keys': 8.59.0
+      '@typescript-eslint/project-service': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/visitor-keys': 8.58.2
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
@@ -5666,26 +6228,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.59.0(eslint@10.2.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.58.2(eslint@10.2.0)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1)
-      '@typescript-eslint/scope-manager': 8.59.0
-      '@typescript-eslint/types': 8.59.0
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
-      eslint: 10.2.1
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.0)
+      '@typescript-eslint/scope-manager': 8.58.2
+      '@typescript-eslint/types': 8.58.2
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
+      eslint: 10.2.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.59.0':
+  '@typescript-eslint/visitor-keys@8.58.2':
     dependencies:
-      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
 
-  '@vercel/backends@0.2.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.2)(typescript@5.9.3)':
+  '@vercel/backends@0.2.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)':
     dependencies:
       '@vercel/build-utils': 13.20.0
-      '@vercel/nft': 1.5.0(rollup@4.60.2)
+      '@vercel/nft': 1.5.0(rollup@4.60.1)
       '@yarnpkg/parsers': 3.0.3
       execa: 3.2.0
       fs-extra: 11.1.0
@@ -5719,9 +6281,9 @@ snapshots:
       cjs-module-lexer: 1.2.3
       es-module-lexer: 1.5.0
 
-  '@vercel/cervel@0.0.55(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.2)(typescript@5.9.3)':
+  '@vercel/cervel@0.0.55(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)':
     dependencies:
-      '@vercel/backends': 0.2.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.2)(typescript@5.9.3)
+      '@vercel/backends': 0.2.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@emnapi/core'
@@ -5732,9 +6294,9 @@ snapshots:
 
   '@vercel/detect-agent@1.2.3': {}
 
-  '@vercel/elysia@0.1.71(rollup@4.60.2)':
+  '@vercel/elysia@0.1.71(rollup@4.60.1)':
     dependencies:
-      '@vercel/node': 5.7.13(rollup@4.60.2)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
     transitivePeerDependencies:
       - encoding
@@ -5743,11 +6305,11 @@ snapshots:
 
   '@vercel/error-utils@2.0.3': {}
 
-  '@vercel/express@0.1.81(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.2)(typescript@5.9.3)':
+  '@vercel/express@0.1.81(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)':
     dependencies:
-      '@vercel/cervel': 0.0.55(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.2)(typescript@5.9.3)
-      '@vercel/nft': 1.5.0(rollup@4.60.2)
-      '@vercel/node': 5.7.13(rollup@4.60.2)
+      '@vercel/cervel': 0.0.55(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)
+      '@vercel/nft': 1.5.0(rollup@4.60.1)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
@@ -5761,9 +6323,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@vercel/fastify@0.1.74(rollup@4.60.2)':
+  '@vercel/fastify@0.1.74(rollup@4.60.1)':
     dependencies:
-      '@vercel/node': 5.7.13(rollup@4.60.2)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
     transitivePeerDependencies:
       - encoding
@@ -5808,19 +6370,19 @@ snapshots:
 
   '@vercel/go@3.5.0': {}
 
-  '@vercel/h3@0.1.80(rollup@4.60.2)':
+  '@vercel/h3@0.1.80(rollup@4.60.1)':
     dependencies:
-      '@vercel/node': 5.7.13(rollup@4.60.2)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/hono@0.2.74(rollup@4.60.2)':
+  '@vercel/hono@0.2.74(rollup@4.60.1)':
     dependencies:
-      '@vercel/nft': 1.5.0(rollup@4.60.2)
-      '@vercel/node': 5.7.13(rollup@4.60.2)
+      '@vercel/nft': 1.5.0(rollup@4.60.1)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
@@ -5836,36 +6398,36 @@ snapshots:
       '@vercel/static-config': 3.2.0
       ts-morph: 12.0.0
 
-  '@vercel/koa@0.1.54(rollup@4.60.2)':
+  '@vercel/koa@0.1.54(rollup@4.60.1)':
     dependencies:
-      '@vercel/node': 5.7.13(rollup@4.60.2)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/nestjs@0.2.75(rollup@4.60.2)':
+  '@vercel/nestjs@0.2.75(rollup@4.60.1)':
     dependencies:
-      '@vercel/node': 5.7.13(rollup@4.60.2)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/next@4.16.8(rollup@4.60.2)':
+  '@vercel/next@4.16.8(rollup@4.60.1)':
     dependencies:
-      '@vercel/nft': 1.5.0(rollup@4.60.2)
+      '@vercel/nft': 1.5.0(rollup@4.60.1)
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/nft@1.5.0(rollup@4.60.2)':
+  '@vercel/nft@1.5.0(rollup@4.60.1)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
-      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
       acorn: 8.16.0
       acorn-import-attributes: 1.9.5(acorn@8.16.0)
       async-sema: 3.1.1
@@ -5881,7 +6443,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/node@5.7.13(rollup@4.60.2)':
+  '@vercel/node@5.7.13(rollup@4.60.1)':
     dependencies:
       '@edge-runtime/node-utils': 2.3.0
       '@edge-runtime/primitives': 4.1.0
@@ -5889,7 +6451,7 @@ snapshots:
       '@types/node': 20.11.0
       '@vercel/build-utils': 13.20.0
       '@vercel/error-utils': 2.0.3
-      '@vercel/nft': 1.5.0(rollup@4.60.2)
+      '@vercel/nft': 1.5.0(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
       async-listen: 3.0.0
       cjs-module-lexer: 1.2.3
@@ -5910,6 +6472,8 @@ snapshots:
       - rollup
       - supports-color
 
+  '@vercel/oidc@3.1.0': {}
+
   '@vercel/oidc@3.2.0': {}
 
   '@vercel/prepare-flags-definitions@0.2.1': {}
@@ -5928,9 +6492,9 @@ snapshots:
     dependencies:
       '@vercel/python-analysis': 0.11.0
 
-  '@vercel/redwood@2.4.12(rollup@4.60.2)':
+  '@vercel/redwood@2.4.12(rollup@4.60.1)':
     dependencies:
-      '@vercel/nft': 1.5.0(rollup@4.60.2)
+      '@vercel/nft': 1.5.0(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
       semver: 6.3.1
       ts-morph: 12.0.0
@@ -5939,10 +6503,10 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/remix-builder@5.7.2(rollup@4.60.2)':
+  '@vercel/remix-builder@5.7.2(rollup@4.60.1)':
     dependencies:
       '@vercel/error-utils': 2.0.3
-      '@vercel/nft': 1.5.0(rollup@4.60.2)
+      '@vercel/nft': 1.5.0(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
       path-to-regexp: 6.1.0
       path-to-regexp-updated: path-to-regexp@6.3.0
@@ -5987,58 +6551,58 @@ snapshots:
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
-  '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
+  '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.5
+      '@vitest/utils': 4.1.4
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.2
       obug: 2.1.1
-      std-env: 4.1.0
+      std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3))
 
-  '@vitest/expect@4.1.5':
+  '@vitest/expect@4.1.4':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.4(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 4.1.5
+      '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/pretty-format@4.1.5':
+  '@vitest/pretty-format@4.1.4':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.5':
+  '@vitest/runner@4.1.4':
     dependencies:
-      '@vitest/utils': 4.1.5
+      '@vitest/utils': 4.1.4
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.5':
+  '@vitest/snapshot@4.1.4':
     dependencies:
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.5': {}
+  '@vitest/spy@4.1.4': {}
 
-  '@vitest/utils@4.1.5':
+  '@vitest/utils@4.1.4':
     dependencies:
-      '@vitest/pretty-format': 4.1.5
+      '@vitest/pretty-format': 4.1.4
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -6070,9 +6634,9 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ai@6.0.168(zod@4.3.6):
+  ai@6.0.161(zod@4.3.6):
     dependencies:
-      '@ai-sdk/gateway': 3.0.104(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.98(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
@@ -6155,7 +6719,10 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  basic-ftp@5.3.0: {}
+  baseline-browser-mapping@2.10.20:
+    optional: true
+
+  basic-ftp@5.2.2: {}
 
   bindings@1.5.0:
     dependencies:
@@ -6206,6 +6773,8 @@ snapshots:
 
   buffer-crc32@0.2.13: {}
 
+  buffer-layout@1.2.2: {}
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -6237,6 +6806,11 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  camelcase@6.3.0: {}
+
+  caniuse-lite@1.0.30001788:
+    optional: true
+
   chai@6.2.2: {}
 
   chalk@5.6.2: {}
@@ -6253,6 +6827,9 @@ snapshots:
 
   cjs-module-lexer@1.2.3: {}
 
+  client-only@0.0.1:
+    optional: true
+
   cluster-key-slot@1.1.2: {}
 
   code-block-writer@10.1.1: {}
@@ -6262,6 +6839,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   commander@11.1.0: {}
+
+  commander@13.1.0: {}
 
   commander@14.0.3: {}
 
@@ -6295,6 +6874,12 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6381,7 +6966,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.3
+      hasown: 2.0.2
 
   es6-promise@4.2.8: {}
 
@@ -6488,18 +7073,18 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-prettier@10.1.8(eslint@10.2.1):
+  eslint-config-prettier@10.1.8(eslint@10.2.0):
     dependencies:
-      eslint: 10.2.1
+      eslint: 10.2.0
 
-  eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@10.2.1))(eslint@10.2.1)(prettier@3.8.3):
+  eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@10.2.0))(eslint@10.2.0)(prettier@3.8.3):
     dependencies:
-      eslint: 10.2.1
+      eslint: 10.2.0
       prettier: 3.8.3
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@10.2.1)
+      eslint-config-prettier: 10.1.8(eslint@10.2.0)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -6512,15 +7097,15 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.2.1:
+  eslint@10.2.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.2.0)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.5.5
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.1
-      '@humanfs/node': 0.16.8
+      '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
@@ -6575,6 +7160,8 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.4: {}
 
   events-intercept@2.0.0: {}
@@ -6587,11 +7174,9 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
-  eventsource-parser@3.0.8: {}
-
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.8
+      eventsource-parser: 3.0.6
 
   execa@3.2.0:
     dependencies:
@@ -6738,7 +7323,7 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   forwarded@0.2.0: {}
@@ -6750,13 +7335,13 @@ snapshots:
   fs-extra@11.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      jsonfile: 6.2.1
+      jsonfile: 6.2.0
       universalify: 2.0.1
 
   fs-extra@11.1.1:
     dependencies:
       graceful-fs: 4.2.11
-      jsonfile: 6.2.1
+      jsonfile: 6.2.0
       universalify: 2.0.1
 
   fsevents@2.3.3:
@@ -6778,7 +7363,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.2
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
@@ -6798,7 +7383,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.3.0
+      basic-ftp: 5.2.2
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -6830,7 +7415,7 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.3:
+  hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
 
@@ -6987,7 +7572,7 @@ snapshots:
 
   json-stringify-safe@5.0.1: {}
 
-  jsonfile@6.2.1:
+  jsonfile@6.2.0:
     dependencies:
       universalify: 2.0.1
     optionalDependencies:
@@ -7042,12 +7627,14 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)):
+  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(next@16.2.4(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.4))(react@19.2.4)):
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       chalk: 5.6.2
       commander: 11.1.0
       redis: 4.7.1
+    optionalDependencies:
+      next: 16.2.4(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.4))(react@19.2.4)
 
   media-typer@1.1.0: {}
 
@@ -7130,6 +7717,32 @@ snapshots:
   negotiator@1.0.0: {}
 
   netmask@2.1.1: {}
+
+  next@16.2.4(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@next/env': 16.2.4
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.20
+      caniuse-lite: 1.0.30001788
+      postcss: 8.4.31
+      react: 19.2.4
+      react-dom: 19.2.5(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.4
+      '@next/swc-darwin-x64': 16.2.4
+      '@next/swc-linux-arm64-gnu': 16.2.4
+      '@next/swc-linux-arm64-musl': 16.2.4
+      '@next/swc-linux-x64-gnu': 16.2.4
+      '@next/swc-linux-x64-musl': 16.2.4
+      '@next/swc-win32-arm64-msvc': 16.2.4
+      '@next/swc-win32-x64-msvc': 16.2.4
+      '@opentelemetry/api': 1.9.0
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    optional: true
 
   node-fetch@2.6.7:
     dependencies:
@@ -7240,6 +7853,8 @@ snapshots:
       degenerator: 5.0.1
       netmask: 2.1.1
 
+  pako@2.1.0: {}
+
   parse-ms@2.1.0: {}
 
   parseurl@1.3.3: {}
@@ -7269,6 +7884,18 @@ snapshots:
 
   pend@1.2.0: {}
 
+  pg-int8@1.0.1: {}
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
   picocolors@1.0.0: {}
 
   picocolors@1.1.1: {}
@@ -7287,19 +7914,36 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3):
+  postcss-load-config@6.0.1(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      postcss: 8.5.10
+      postcss: 8.5.9
       tsx: 4.21.0
       yaml: 2.8.3
 
-  postcss@8.5.10:
+  postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+    optional: true
+
+  postcss@8.5.9:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -7363,6 +8007,12 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  react-dom@19.2.5(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+    optional: true
 
   react@19.2.4:
     optional: true
@@ -7454,35 +8104,35 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.0
       fsevents: 2.3.3
 
-  rollup@4.60.2:
+  rollup@4.60.1:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.60.2
-      '@rollup/rollup-android-arm64': 4.60.2
-      '@rollup/rollup-darwin-arm64': 4.60.2
-      '@rollup/rollup-darwin-x64': 4.60.2
-      '@rollup/rollup-freebsd-arm64': 4.60.2
-      '@rollup/rollup-freebsd-x64': 4.60.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
-      '@rollup/rollup-linux-arm64-gnu': 4.60.2
-      '@rollup/rollup-linux-arm64-musl': 4.60.2
-      '@rollup/rollup-linux-loong64-gnu': 4.60.2
-      '@rollup/rollup-linux-loong64-musl': 4.60.2
-      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
-      '@rollup/rollup-linux-ppc64-musl': 4.60.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
-      '@rollup/rollup-linux-riscv64-musl': 4.60.2
-      '@rollup/rollup-linux-s390x-gnu': 4.60.2
-      '@rollup/rollup-linux-x64-gnu': 4.60.2
-      '@rollup/rollup-linux-x64-musl': 4.60.2
-      '@rollup/rollup-openbsd-x64': 4.60.2
-      '@rollup/rollup-openharmony-arm64': 4.60.2
-      '@rollup/rollup-win32-arm64-msvc': 4.60.2
-      '@rollup/rollup-win32-ia32-msvc': 4.60.2
-      '@rollup/rollup-win32-x64-gnu': 4.60.2
-      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      '@rollup/rollup-android-arm-eabi': 4.60.1
+      '@rollup/rollup-android-arm64': 4.60.1
+      '@rollup/rollup-darwin-arm64': 4.60.1
+      '@rollup/rollup-darwin-x64': 4.60.1
+      '@rollup/rollup-freebsd-arm64': 4.60.1
+      '@rollup/rollup-freebsd-x64': 4.60.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
+      '@rollup/rollup-linux-arm64-gnu': 4.60.1
+      '@rollup/rollup-linux-arm64-musl': 4.60.1
+      '@rollup/rollup-linux-loong64-gnu': 4.60.1
+      '@rollup/rollup-linux-loong64-musl': 4.60.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
+      '@rollup/rollup-linux-ppc64-musl': 4.60.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
+      '@rollup/rollup-linux-riscv64-musl': 4.60.1
+      '@rollup/rollup-linux-s390x-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-musl': 4.60.1
+      '@rollup/rollup-openbsd-x64': 4.60.1
+      '@rollup/rollup-openharmony-arm64': 4.60.1
+      '@rollup/rollup-win32-arm64-msvc': 4.60.1
+      '@rollup/rollup-win32-ia32-msvc': 4.60.1
+      '@rollup/rollup-win32-x64-gnu': 4.60.1
+      '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
   router@2.2.0:
@@ -7526,6 +8176,9 @@ snapshots:
       - react-native-b4a
       - supports-color
 
+  scheduler@0.27.0:
+    optional: true
+
   semver@6.3.1: {}
 
   semver@7.5.4:
@@ -7562,6 +8215,38 @@ snapshots:
   setprototypeof@1.1.1: {}
 
   setprototypeof@1.2.0: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -7641,7 +8326,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@4.1.0: {}
+  std-env@4.0.0: {}
 
   stream-chain@2.2.5: {}
 
@@ -7670,6 +8355,12 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
+  styled-jsx@5.1.6(react@19.2.4):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.4
+    optional: true
+
   sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -7677,8 +8368,10 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  superstruct@0.15.5: {}
 
   superstruct@2.0.2: {}
 
@@ -7763,6 +8456,8 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  toml@3.0.0: {}
+
   tr46@0.0.3: {}
 
   tree-kill@1.2.2: {}
@@ -7782,7 +8477,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  tsup@8.5.1(postcss@8.5.9)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14
@@ -7793,7 +8488,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.10)(tsx@4.21.0)(yaml@2.8.3)
+      postcss-load-config: 6.0.1(postcss@8.5.9)(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.0
       source-map: 0.7.6
@@ -7802,7 +8497,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.10
+      postcss: 8.5.9
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -7827,13 +8522,13 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript-eslint@8.59.0(eslint@10.2.1)(typescript@5.9.3):
+  typescript-eslint@8.58.2(eslint@10.2.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@5.9.3))(eslint@10.2.1)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.59.0(eslint@10.2.1)(typescript@5.9.3)
-      eslint: 10.2.1
+      '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.2(eslint@10.2.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.2(eslint@10.2.0)(typescript@5.9.3)
+      eslint: 10.2.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -7845,6 +8540,8 @@ snapshots:
   uid-promise@1.0.0: {}
 
   undici-types@5.26.5: {}
+
+  undici-types@6.21.0: {}
 
   undici-types@7.19.2: {}
 
@@ -7877,28 +8574,28 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vercel@52.0.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.2)(typescript@5.9.3):
+  vercel@52.0.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3):
     dependencies:
-      '@vercel/backends': 0.2.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.2)(typescript@5.9.3)
+      '@vercel/backends': 0.2.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)
       '@vercel/blob': 2.3.0
       '@vercel/build-utils': 13.20.0
       '@vercel/detect-agent': 1.2.3
-      '@vercel/elysia': 0.1.71(rollup@4.60.2)
-      '@vercel/express': 0.1.81(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.2)(typescript@5.9.3)
-      '@vercel/fastify': 0.1.74(rollup@4.60.2)
+      '@vercel/elysia': 0.1.71(rollup@4.60.1)
+      '@vercel/express': 0.1.81(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(rollup@4.60.1)(typescript@5.9.3)
+      '@vercel/fastify': 0.1.74(rollup@4.60.1)
       '@vercel/fun': 1.3.0
       '@vercel/go': 3.5.0
-      '@vercel/h3': 0.1.80(rollup@4.60.2)
-      '@vercel/hono': 0.2.74(rollup@4.60.2)
+      '@vercel/h3': 0.1.80(rollup@4.60.1)
+      '@vercel/hono': 0.2.74(rollup@4.60.1)
       '@vercel/hydrogen': 1.3.6
-      '@vercel/koa': 0.1.54(rollup@4.60.2)
-      '@vercel/nestjs': 0.2.75(rollup@4.60.2)
-      '@vercel/next': 4.16.8(rollup@4.60.2)
-      '@vercel/node': 5.7.13(rollup@4.60.2)
+      '@vercel/koa': 0.1.54(rollup@4.60.1)
+      '@vercel/nestjs': 0.2.75(rollup@4.60.1)
+      '@vercel/next': 4.16.8(rollup@4.60.1)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/prepare-flags-definitions': 0.2.1
       '@vercel/python': 6.36.0
-      '@vercel/redwood': 2.4.12(rollup@4.60.2)
-      '@vercel/remix-builder': 5.7.2(rollup@4.60.2)
+      '@vercel/redwood': 2.4.12(rollup@4.60.1)
+      '@vercel/remix-builder': 5.7.2(rollup@4.60.1)
       '@vercel/ruby': 2.3.2
       '@vercel/rust': 1.1.1
       '@vercel/static-build': 2.9.21
@@ -7925,8 +8622,8 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.10
-      rollup: 4.60.2
+      postcss: 8.5.9
+      rollup: 4.60.1
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.6.0
@@ -7934,22 +8631,22 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.5(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@7.3.1(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 4.1.0
+      std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
@@ -7960,7 +8657,7 @@ snapshots:
       '@edge-runtime/vm': 3.2.0
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.6.0
-      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
     transitivePeerDependencies:
       - msw
 
@@ -8003,6 +8700,8 @@ snapshots:
   xdg-portable@7.3.0:
     dependencies:
       os-paths: 4.4.0
+
+  xtend@4.0.2: {}
 
   yallist@4.0.0: {}
 

--- a/tests/unit/solana/inspect-entity.test.ts
+++ b/tests/unit/solana/inspect-entity.test.ts
@@ -383,13 +383,85 @@ describe("inspect_entity handler", () => {
     expect(resolveMetaplexMetadata).not.toHaveBeenCalled();
   });
 
-  it("returns CURRENTLY_UNSUPPORTED for transaction identifiers", async () => {
-    const result = await handleInspectEntity({ identifier: TRANSACTION_IDENTIFIER });
+  it("returns NOT_FOUND for transaction identifiers when envelope is null", async () => {
+    const dependencies = createDependencies({
+      fetchTransaction: vi.fn().mockResolvedValue(null),
+    });
+
+    const result = await handleInspectEntity({ identifier: TRANSACTION_IDENTIFIER }, dependencies);
     const envelope = parseEnvelope(result);
 
     expect(result.isError).toBe(true);
     expect(envelope).toMatchObject({
-      errors: [{ code: "CURRENTLY_UNSUPPORTED" }],
+      payload: { entity: { kind: "transaction" } },
+      errors: [{ code: "NOT_FOUND" }],
+    });
+  });
+
+  it("resolves a valid transaction with signature status", async () => {
+    const dependencies = createDependencies({
+      fetchTransaction: vi.fn().mockResolvedValue({
+        slot: 123456,
+        blockTime: 1700000000,
+        version: "legacy",
+        meta: {
+          err: null,
+          fee: 5000,
+          computeUnitsConsumed: 1000,
+          logMessages: ["Program log: success"],
+          innerInstructions: [],
+        },
+        transaction: {
+          message: {
+            header: {
+              numRequiredSignatures: 1,
+              numReadonlySignedAccounts: 0,
+              numReadonlyUnsignedAccounts: 1,
+            },
+            accountKeys: ["signer1", "program1"],
+            recentBlockhash: "blockhash",
+            instructions: [{ programIdIndex: 1, accounts: [0], data: "data" }],
+          },
+        },
+      }),
+      fetchSignatureStatus: vi.fn().mockResolvedValue({
+        value: { confirmationStatus: "finalized", confirmations: null },
+      }),
+    });
+
+    const result = await handleInspectEntity({ identifier: TRANSACTION_IDENTIFIER }, dependencies);
+    const envelope = parseEnvelope(result);
+
+    expect(result.isError).toBe(false);
+    expect(envelope).toMatchObject({
+      payload: {
+        entity: {
+          kind: "transaction",
+          signature: TRANSACTION_IDENTIFIER,
+          slot: 123456,
+          status: "success",
+        },
+      },
+      errors: [],
+    });
+  });
+
+  it("maps transaction SourceUnavailableError to INTERNAL_ERROR with source marker", async () => {
+    const dependencies = createDependencies({
+      fetchTransaction: vi.fn().mockRejectedValue(new SourceUnavailableError("RPC timeout")),
+    });
+
+    const result = await handleInspectEntity({ identifier: TRANSACTION_IDENTIFIER }, dependencies);
+    const envelope = parseEnvelope(result);
+
+    expect(envelope).toMatchObject({
+      payload: {
+        entity: {
+          kind: "transaction",
+          source: { value: null, status: "unknown", reason: "source_unavailable" },
+        },
+      },
+      errors: [{ code: "INTERNAL_ERROR" }],
     });
   });
 

--- a/tests/unit/solana/resolvers/metaplex-metadata.test.ts
+++ b/tests/unit/solana/resolvers/metaplex-metadata.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { buildMetaplexMetadataField } from "../../../lib/solana/account-kinds/shared";
-import type { MetaplexMetadataResult } from "../../../lib/solana/types";
+import { buildMetaplexMetadataField } from "../../../../lib/solana/account-kinds/shared";
+import type { MetaplexMetadataResult } from "../../../../lib/solana/types";
 
 describe("buildMetaplexMetadataField", () => {
   it("returns null when result is undefined", () => {

--- a/tests/unit/solana/transaction/account-resolver.test.ts
+++ b/tests/unit/solana/transaction/account-resolver.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from "vitest";
 
+import type { AccountRole, ResolvedAccount } from "../../../../lib/solana/types";
 import {
   resolveStaticAccounts,
   resolveV0Accounts,
   selectAccountResolver,
 } from "../../../../lib/solana/transaction/account-resolver";
+
+function staticAccount(role: AccountRole): ResolvedAccount {
+  return { ...role, source: "static" };
+}
+
+function lookupTableAccount(role: AccountRole, lookupTableAddress?: string): ResolvedAccount {
+  return { ...role, source: "lookupTable", ...(lookupTableAddress != null && { lookupTableAddress }) };
+}
 
 describe("resolveStaticAccounts", () => {
   it("classifies single signer with no readonly", () => {
@@ -15,8 +24,8 @@ describe("resolveStaticAccounts", () => {
 
     expect(result.accountKeys).toEqual(["fee-payer", "other"]);
     expect(result.resolvedAccounts).toEqual([
-      { address: "fee-payer", signer: true, writable: true },
-      { address: "other", signer: false, writable: true },
+      staticAccount({ address: "fee-payer", signer: true, writable: true }),
+      staticAccount({ address: "other", signer: false, writable: true }),
     ]);
   });
 
@@ -27,10 +36,10 @@ describe("resolveStaticAccounts", () => {
     });
 
     expect(result.resolvedAccounts).toEqual([
-      { address: "fee-payer", signer: true, writable: true },
-      { address: "readonly-signer", signer: true, writable: false },
-      { address: "writable-nonsigner", signer: false, writable: true },
-      { address: "program", signer: false, writable: false },
+      staticAccount({ address: "fee-payer", signer: true, writable: true }),
+      staticAccount({ address: "readonly-signer", signer: true, writable: false }),
+      staticAccount({ address: "writable-nonsigner", signer: false, writable: true }),
+      staticAccount({ address: "program", signer: false, writable: false }),
     ]);
   });
 
@@ -41,10 +50,10 @@ describe("resolveStaticAccounts", () => {
     });
 
     expect(result.resolvedAccounts).toEqual([
-      { address: "fee-payer", signer: true, writable: true },
-      { address: "cosigner-ro-1", signer: true, writable: false },
-      { address: "cosigner-ro-2", signer: true, writable: false },
-      { address: "other", signer: false, writable: true },
+      staticAccount({ address: "fee-payer", signer: true, writable: true }),
+      staticAccount({ address: "cosigner-ro-1", signer: true, writable: false }),
+      staticAccount({ address: "cosigner-ro-2", signer: true, writable: false }),
+      staticAccount({ address: "other", signer: false, writable: true }),
     ]);
   });
 
@@ -55,9 +64,9 @@ describe("resolveStaticAccounts", () => {
     });
 
     expect(result.resolvedAccounts).toEqual([
-      { address: "signer-a", signer: true, writable: true },
-      { address: "signer-b", signer: true, writable: true },
-      { address: "other", signer: false, writable: true },
+      staticAccount({ address: "signer-a", signer: true, writable: true }),
+      staticAccount({ address: "signer-b", signer: true, writable: true }),
+      staticAccount({ address: "other", signer: false, writable: true }),
     ]);
   });
 
@@ -80,6 +89,7 @@ describe("resolveStaticAccounts", () => {
 
     expect(result.accountKeys).toEqual(["signer", "program"]);
     expect(result.resolvedAccounts).toHaveLength(2);
+    expect(result.resolvedAccounts.every(a => a.source === "static")).toBe(true);
   });
 });
 
@@ -93,13 +103,45 @@ describe("resolveV0Accounts", () => {
 
     expect(result.accountKeys).toEqual(["signer", "program", "readonly", "alt-w1", "alt-w2", "alt-r1"]);
     expect(result.resolvedAccounts).toEqual([
-      { address: "signer", signer: true, writable: true },
-      { address: "program", signer: false, writable: true },
-      { address: "readonly", signer: false, writable: false },
-      { address: "alt-w1", signer: false, writable: true },
-      { address: "alt-w2", signer: false, writable: true },
-      { address: "alt-r1", signer: false, writable: false },
+      staticAccount({ address: "signer", signer: true, writable: true }),
+      staticAccount({ address: "program", signer: false, writable: true }),
+      staticAccount({ address: "readonly", signer: false, writable: false }),
+      lookupTableAccount({ address: "alt-w1", signer: false, writable: true }),
+      lookupTableAccount({ address: "alt-w2", signer: false, writable: true }),
+      lookupTableAccount({ address: "alt-r1", signer: false, writable: false }),
     ]);
+  });
+
+  it("tags loaded accounts with their lookup table address", () => {
+    const result = resolveV0Accounts({
+      staticKeys: ["signer"],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 0 },
+      loadedAddresses: { writable: ["alt-w1", "alt-w2", "alt-w3"], readonly: ["alt-r1"] },
+      addressTableLookups: [
+        { accountKey: "ALT-A", writableIndexes: [0, 3], readonlyIndexes: [1] },
+        { accountKey: "ALT-B", writableIndexes: [2], readonlyIndexes: [] },
+      ],
+    });
+
+    expect(result.resolvedAccounts).toEqual([
+      staticAccount({ address: "signer", signer: true, writable: true }),
+      lookupTableAccount({ address: "alt-w1", signer: false, writable: true }, "ALT-A"),
+      lookupTableAccount({ address: "alt-w2", signer: false, writable: true }, "ALT-A"),
+      lookupTableAccount({ address: "alt-w3", signer: false, writable: true }, "ALT-B"),
+      lookupTableAccount({ address: "alt-r1", signer: false, writable: false }, "ALT-A"),
+    ]);
+  });
+
+  it("omits lookupTableAddress when addressTableLookups is not provided", () => {
+    const result = resolveV0Accounts({
+      staticKeys: ["signer"],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 0 },
+      loadedAddresses: { writable: ["alt-w1"], readonly: [] },
+    });
+
+    const loaded = result.resolvedAccounts[1]!;
+    expect(loaded.source).toBe("lookupTable");
+    expect(loaded).not.toHaveProperty("lookupTableAddress");
   });
 
   it("behaves like static resolver when loadedAddresses is null", () => {
@@ -111,8 +153,8 @@ describe("resolveV0Accounts", () => {
 
     expect(result.accountKeys).toEqual(["signer", "program"]);
     expect(result.resolvedAccounts).toEqual([
-      { address: "signer", signer: true, writable: true },
-      { address: "program", signer: false, writable: false },
+      staticAccount({ address: "signer", signer: true, writable: true }),
+      staticAccount({ address: "program", signer: false, writable: false }),
     ]);
   });
 
@@ -135,7 +177,9 @@ describe("resolveV0Accounts", () => {
     });
 
     expect(result.accountKeys).toEqual(["signer", "alt-w1"]);
-    expect(result.resolvedAccounts[1]).toEqual({ address: "alt-w1", signer: false, writable: true });
+    expect(result.resolvedAccounts[1]).toEqual(
+      lookupTableAccount({ address: "alt-w1", signer: false, writable: true }),
+    );
   });
 
   it("appends only loaded readonly when no loaded writable", () => {
@@ -146,7 +190,9 @@ describe("resolveV0Accounts", () => {
     });
 
     expect(result.accountKeys).toEqual(["signer", "alt-r1"]);
-    expect(result.resolvedAccounts[1]).toEqual({ address: "alt-r1", signer: false, writable: false });
+    expect(result.resolvedAccounts[1]).toEqual(
+      lookupTableAccount({ address: "alt-r1", signer: false, writable: false }),
+    );
   });
 });
 

--- a/tests/unit/solana/transaction/account-resolver.test.ts
+++ b/tests/unit/solana/transaction/account-resolver.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveStaticAccounts,
+  resolveV0Accounts,
+  selectAccountResolver,
+} from "../../../../lib/solana/transaction/account-resolver";
+
+describe("resolveStaticAccounts", () => {
+  it("classifies single signer with no readonly", () => {
+    const result = resolveStaticAccounts({
+      staticKeys: ["fee-payer", "other"],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 0 },
+    });
+
+    expect(result.accountKeys).toEqual(["fee-payer", "other"]);
+    expect(result.resolvedAccounts).toEqual([
+      { address: "fee-payer", signer: true, writable: true },
+      { address: "other", signer: false, writable: true },
+    ]);
+  });
+
+  it("classifies mixed signers with readonly signed and unsigned", () => {
+    const result = resolveStaticAccounts({
+      staticKeys: ["fee-payer", "readonly-signer", "writable-nonsigner", "program"],
+      header: { numRequiredSignatures: 2, numReadonlySignedAccounts: 1, numReadonlyUnsignedAccounts: 1 },
+    });
+
+    expect(result.resolvedAccounts).toEqual([
+      { address: "fee-payer", signer: true, writable: true },
+      { address: "readonly-signer", signer: true, writable: false },
+      { address: "writable-nonsigner", signer: false, writable: true },
+      { address: "program", signer: false, writable: false },
+    ]);
+  });
+
+  it("classifies multiple readonly signers", () => {
+    const result = resolveStaticAccounts({
+      staticKeys: ["fee-payer", "cosigner-ro-1", "cosigner-ro-2", "other"],
+      header: { numRequiredSignatures: 3, numReadonlySignedAccounts: 2, numReadonlyUnsignedAccounts: 0 },
+    });
+
+    expect(result.resolvedAccounts).toEqual([
+      { address: "fee-payer", signer: true, writable: true },
+      { address: "cosigner-ro-1", signer: true, writable: false },
+      { address: "cosigner-ro-2", signer: true, writable: false },
+      { address: "other", signer: false, writable: true },
+    ]);
+  });
+
+  it("marks all accounts writable when both readonly counts are zero", () => {
+    const result = resolveStaticAccounts({
+      staticKeys: ["signer-a", "signer-b", "other"],
+      header: { numRequiredSignatures: 2, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 0 },
+    });
+
+    expect(result.resolvedAccounts).toEqual([
+      { address: "signer-a", signer: true, writable: true },
+      { address: "signer-b", signer: true, writable: true },
+      { address: "other", signer: false, writable: true },
+    ]);
+  });
+
+  it("returns accountKeys identical to staticKeys input", () => {
+    const staticKeys = ["a", "b", "c"];
+    const result = resolveStaticAccounts({
+      staticKeys,
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 0 },
+    });
+
+    expect(result.accountKeys).toEqual(staticKeys);
+  });
+
+  it("ignores loadedAddresses when provided", () => {
+    const result = resolveStaticAccounts({
+      staticKeys: ["signer", "program"],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 1 },
+      loadedAddresses: { writable: ["alt-w1"], readonly: ["alt-r1"] },
+    });
+
+    expect(result.accountKeys).toEqual(["signer", "program"]);
+    expect(result.resolvedAccounts).toHaveLength(2);
+  });
+});
+
+describe("resolveV0Accounts", () => {
+  it("merges static keys with loaded writable and readonly", () => {
+    const result = resolveV0Accounts({
+      staticKeys: ["signer", "program", "readonly"],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 1 },
+      loadedAddresses: { writable: ["alt-w1", "alt-w2"], readonly: ["alt-r1"] },
+    });
+
+    expect(result.accountKeys).toEqual(["signer", "program", "readonly", "alt-w1", "alt-w2", "alt-r1"]);
+    expect(result.resolvedAccounts).toEqual([
+      { address: "signer", signer: true, writable: true },
+      { address: "program", signer: false, writable: true },
+      { address: "readonly", signer: false, writable: false },
+      { address: "alt-w1", signer: false, writable: true },
+      { address: "alt-w2", signer: false, writable: true },
+      { address: "alt-r1", signer: false, writable: false },
+    ]);
+  });
+
+  it("behaves like static resolver when loadedAddresses is null", () => {
+    const result = resolveV0Accounts({
+      staticKeys: ["signer", "program"],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 1 },
+      loadedAddresses: null,
+    });
+
+    expect(result.accountKeys).toEqual(["signer", "program"]);
+    expect(result.resolvedAccounts).toEqual([
+      { address: "signer", signer: true, writable: true },
+      { address: "program", signer: false, writable: false },
+    ]);
+  });
+
+  it("behaves like static resolver when loadedAddresses arrays are empty", () => {
+    const result = resolveV0Accounts({
+      staticKeys: ["signer", "program"],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 1 },
+      loadedAddresses: { writable: [], readonly: [] },
+    });
+
+    expect(result.accountKeys).toEqual(["signer", "program"]);
+    expect(result.resolvedAccounts).toHaveLength(2);
+  });
+
+  it("appends only loaded writable when no loaded readonly", () => {
+    const result = resolveV0Accounts({
+      staticKeys: ["signer"],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 0 },
+      loadedAddresses: { writable: ["alt-w1"], readonly: [] },
+    });
+
+    expect(result.accountKeys).toEqual(["signer", "alt-w1"]);
+    expect(result.resolvedAccounts[1]).toEqual({ address: "alt-w1", signer: false, writable: true });
+  });
+
+  it("appends only loaded readonly when no loaded writable", () => {
+    const result = resolveV0Accounts({
+      staticKeys: ["signer"],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 0 },
+      loadedAddresses: { writable: [], readonly: ["alt-r1"] },
+    });
+
+    expect(result.accountKeys).toEqual(["signer", "alt-r1"]);
+    expect(result.resolvedAccounts[1]).toEqual({ address: "alt-r1", signer: false, writable: false });
+  });
+});
+
+describe("selectAccountResolver", () => {
+  it("returns resolveStaticAccounts for legacy", () => {
+    expect(selectAccountResolver("legacy")).toBe(resolveStaticAccounts);
+  });
+
+  it("returns resolveStaticAccounts for null", () => {
+    expect(selectAccountResolver(null)).toBe(resolveStaticAccounts);
+  });
+
+  it("returns resolveStaticAccounts for version 1", () => {
+    expect(selectAccountResolver(1)).toBe(resolveStaticAccounts);
+  });
+
+  it("returns resolveV0Accounts for version 0", () => {
+    expect(selectAccountResolver(0)).toBe(resolveV0Accounts);
+  });
+
+  it("v0 resolver produces different output than static when loadedAddresses present", () => {
+    const params = {
+      staticKeys: ["signer"],
+      header: { numRequiredSignatures: 1, numReadonlySignedAccounts: 0, numReadonlyUnsignedAccounts: 0 },
+      loadedAddresses: { writable: ["alt-w1"], readonly: [] },
+    };
+
+    const v0Result = selectAccountResolver(0)(params);
+    const legacyResult = selectAccountResolver("legacy")(params);
+
+    expect(v0Result.accountKeys).toHaveLength(2);
+    expect(legacyResult.accountKeys).toHaveLength(1);
+  });
+});

--- a/tests/unit/solana/transaction/build-payload.test.ts
+++ b/tests/unit/solana/transaction/build-payload.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import type { TransactionPayloadContext } from "../../../../lib/solana/types";
+import type { AccountRole, ResolvedAccount, TransactionPayloadContext } from "../../../../lib/solana/types";
 import { buildTransactionPayload } from "../../../../lib/solana/transaction/build-payload";
+
+function staticAccount(role: AccountRole): ResolvedAccount {
+  return { ...role, source: "static" };
+}
+
+function lookupTableAccount(role: AccountRole, lookupTableAddress?: string): ResolvedAccount {
+  return { ...role, source: "lookupTable", ...(lookupTableAddress != null && { lookupTableAddress }) };
+}
 
 function makeFullContext(overrides: Partial<TransactionPayloadContext> = {}): TransactionPayloadContext {
   return {
@@ -12,10 +20,10 @@ function makeFullContext(overrides: Partial<TransactionPayloadContext> = {}): Tr
     feeLamports: 5000,
     accountKeys: ["fee-payer", "readonly-signer", "writable-nonsigner", "program"],
     resolvedAccounts: [
-      { address: "fee-payer", signer: true, writable: true },
-      { address: "readonly-signer", signer: true, writable: false },
-      { address: "writable-nonsigner", signer: false, writable: true },
-      { address: "program", signer: false, writable: false },
+      staticAccount({ address: "fee-payer", signer: true, writable: true }),
+      staticAccount({ address: "readonly-signer", signer: true, writable: false }),
+      staticAccount({ address: "writable-nonsigner", signer: false, writable: true }),
+      staticAccount({ address: "program", signer: false, writable: false }),
     ],
     numRequiredSignatures: 2,
     version: 0,
@@ -58,7 +66,7 @@ describe("transaction payload builder", () => {
       makeFullContext({
         numRequiredSignatures: -1,
         accountKeys: ["a"],
-        resolvedAccounts: [{ address: "a", signer: false, writable: true }],
+        resolvedAccounts: [staticAccount({ address: "a", signer: false, writable: true })],
         numReadonlySignedAccounts: 0,
         numReadonlyUnsignedAccounts: 0,
         instructions: [],
@@ -73,10 +81,10 @@ describe("transaction payload builder", () => {
     const result = buildTransactionPayload(makeFullContext());
 
     expect(result.entity.accounts).toEqual([
-      { address: "fee-payer", signer: true, writable: true },
-      { address: "readonly-signer", signer: true, writable: false },
-      { address: "writable-nonsigner", signer: false, writable: true },
-      { address: "program", signer: false, writable: false },
+      staticAccount({ address: "fee-payer", signer: true, writable: true }),
+      staticAccount({ address: "readonly-signer", signer: true, writable: false }),
+      staticAccount({ address: "writable-nonsigner", signer: false, writable: true }),
+      staticAccount({ address: "program", signer: false, writable: false }),
     ]);
   });
 
@@ -125,8 +133,8 @@ describe("transaction payload builder", () => {
       makeFullContext({
         accountKeys: ["payer", "system-program"],
         resolvedAccounts: [
-          { address: "payer", signer: true, writable: true },
-          { address: "system-program", signer: false, writable: false },
+          staticAccount({ address: "payer", signer: true, writable: true }),
+          staticAccount({ address: "system-program", signer: false, writable: false }),
         ],
         numRequiredSignatures: 1,
         numReadonlySignedAccounts: 0,
@@ -137,8 +145,8 @@ describe("transaction payload builder", () => {
     );
 
     expect(result.entity.accounts).toEqual([
-      { address: "payer", signer: true, writable: true },
-      { address: "system-program", signer: false, writable: false },
+      staticAccount({ address: "payer", signer: true, writable: true }),
+      staticAccount({ address: "system-program", signer: false, writable: false }),
     ]);
   });
 
@@ -160,9 +168,9 @@ describe("transaction payload builder", () => {
       makeFullContext({
         accountKeys: ["signer-a", "signer-b", "other"],
         resolvedAccounts: [
-          { address: "signer-a", signer: true, writable: true },
-          { address: "signer-b", signer: true, writable: true },
-          { address: "other", signer: false, writable: true },
+          staticAccount({ address: "signer-a", signer: true, writable: true }),
+          staticAccount({ address: "signer-b", signer: true, writable: true }),
+          staticAccount({ address: "other", signer: false, writable: true }),
         ],
         numRequiredSignatures: 2,
         numReadonlySignedAccounts: 0,
@@ -173,9 +181,9 @@ describe("transaction payload builder", () => {
     );
 
     expect(result.entity.accounts).toEqual([
-      { address: "signer-a", signer: true, writable: true },
-      { address: "signer-b", signer: true, writable: true },
-      { address: "other", signer: false, writable: true },
+      staticAccount({ address: "signer-a", signer: true, writable: true }),
+      staticAccount({ address: "signer-b", signer: true, writable: true }),
+      staticAccount({ address: "other", signer: false, writable: true }),
     ]);
   });
 
@@ -184,10 +192,10 @@ describe("transaction payload builder", () => {
       makeFullContext({
         accountKeys: ["fee-payer", "cosigner-ro-1", "cosigner-ro-2", "other"],
         resolvedAccounts: [
-          { address: "fee-payer", signer: true, writable: true },
-          { address: "cosigner-ro-1", signer: true, writable: false },
-          { address: "cosigner-ro-2", signer: true, writable: false },
-          { address: "other", signer: false, writable: true },
+          staticAccount({ address: "fee-payer", signer: true, writable: true }),
+          staticAccount({ address: "cosigner-ro-1", signer: true, writable: false }),
+          staticAccount({ address: "cosigner-ro-2", signer: true, writable: false }),
+          staticAccount({ address: "other", signer: false, writable: true }),
         ],
         numRequiredSignatures: 3,
         numReadonlySignedAccounts: 2,
@@ -198,10 +206,10 @@ describe("transaction payload builder", () => {
     );
 
     expect(result.entity.accounts).toEqual([
-      { address: "fee-payer", signer: true, writable: true },
-      { address: "cosigner-ro-1", signer: true, writable: false },
-      { address: "cosigner-ro-2", signer: true, writable: false },
-      { address: "other", signer: false, writable: true },
+      staticAccount({ address: "fee-payer", signer: true, writable: true }),
+      staticAccount({ address: "cosigner-ro-1", signer: true, writable: false }),
+      staticAccount({ address: "cosigner-ro-2", signer: true, writable: false }),
+      staticAccount({ address: "other", signer: false, writable: true }),
     ]);
   });
 
@@ -210,10 +218,10 @@ describe("transaction payload builder", () => {
       makeFullContext({
         accountKeys: ["signer", "prog-a", "prog-b", "prog-c"],
         resolvedAccounts: [
-          { address: "signer", signer: true, writable: true },
-          { address: "prog-a", signer: false, writable: false },
-          { address: "prog-b", signer: false, writable: false },
-          { address: "prog-c", signer: false, writable: false },
+          staticAccount({ address: "signer", signer: true, writable: true }),
+          staticAccount({ address: "prog-a", signer: false, writable: false }),
+          staticAccount({ address: "prog-b", signer: false, writable: false }),
+          staticAccount({ address: "prog-c", signer: false, writable: false }),
         ],
         numRequiredSignatures: 1,
         numReadonlySignedAccounts: 0,
@@ -247,9 +255,9 @@ describe("transaction payload builder", () => {
       makeFullContext({
         accountKeys: ["signer", "prog-a", "prog-b"],
         resolvedAccounts: [
-          { address: "signer", signer: true, writable: true },
-          { address: "prog-a", signer: false, writable: false },
-          { address: "prog-b", signer: false, writable: false },
+          staticAccount({ address: "signer", signer: true, writable: true }),
+          staticAccount({ address: "prog-a", signer: false, writable: false }),
+          staticAccount({ address: "prog-b", signer: false, writable: false }),
         ],
         numRequiredSignatures: 1,
         numReadonlySignedAccounts: 0,
@@ -302,12 +310,20 @@ describe("transaction payload builder", () => {
 
   it("uses resolvedAccounts for output accounts", () => {
     const resolvedAccounts = [
-      { address: "fee-payer", signer: true, writable: true },
-      { address: "readonly-signer", signer: true, writable: false },
-      { address: "writable-nonsigner", signer: false, writable: true },
-      { address: "program", signer: false, writable: false },
+      staticAccount({ address: "fee-payer", signer: true, writable: true }),
+      staticAccount({ address: "readonly-signer", signer: true, writable: false }),
     ];
-    const result = buildTransactionPayload(makeFullContext({ resolvedAccounts }));
+    const result = buildTransactionPayload(
+      makeFullContext({
+        accountKeys: ["fee-payer", "readonly-signer"],
+        resolvedAccounts,
+        numRequiredSignatures: 2,
+        numReadonlySignedAccounts: 1,
+        numReadonlyUnsignedAccounts: 0,
+        instructions: [],
+        innerInstructions: null,
+      }),
+    );
 
     expect(result.entity.accounts).toEqual(resolvedAccounts);
   });
@@ -317,10 +333,10 @@ describe("transaction payload builder", () => {
       makeFullContext({
         accountKeys: ["signer", "program", "alt-w1", "alt-r1"],
         resolvedAccounts: [
-          { address: "signer", signer: true, writable: true },
-          { address: "program", signer: false, writable: false },
-          { address: "alt-w1", signer: false, writable: true },
-          { address: "alt-r1", signer: false, writable: false },
+          staticAccount({ address: "signer", signer: true, writable: true }),
+          staticAccount({ address: "program", signer: false, writable: false }),
+          lookupTableAccount({ address: "alt-w1", signer: false, writable: true }, "ALT-A"),
+          lookupTableAccount({ address: "alt-r1", signer: false, writable: false }, "ALT-A"),
         ],
         numRequiredSignatures: 1,
         numReadonlySignedAccounts: 0,
@@ -331,8 +347,12 @@ describe("transaction payload builder", () => {
     );
 
     expect(result.entity.accounts).toHaveLength(4);
-    expect(result.entity.accounts[2]).toEqual({ address: "alt-w1", signer: false, writable: true });
-    expect(result.entity.accounts[3]).toEqual({ address: "alt-r1", signer: false, writable: false });
+    expect(result.entity.accounts[2]).toEqual(
+      lookupTableAccount({ address: "alt-w1", signer: false, writable: true }, "ALT-A"),
+    );
+    expect(result.entity.accounts[3]).toEqual(
+      lookupTableAccount({ address: "alt-r1", signer: false, writable: false }, "ALT-A"),
+    );
     expect(result.entity.instructions[0]!.accounts).toEqual(["signer", "alt-w1", "alt-r1"]);
   });
 

--- a/tests/unit/solana/transaction/build-payload.test.ts
+++ b/tests/unit/solana/transaction/build-payload.test.ts
@@ -11,6 +11,12 @@ function makeFullContext(overrides: Partial<TransactionPayloadContext> = {}): Tr
     status: "success",
     feeLamports: 5000,
     accountKeys: ["fee-payer", "readonly-signer", "writable-nonsigner", "program"],
+    resolvedAccounts: [
+      { address: "fee-payer", signer: true, writable: true },
+      { address: "readonly-signer", signer: true, writable: false },
+      { address: "writable-nonsigner", signer: false, writable: true },
+      { address: "program", signer: false, writable: false },
+    ],
     numRequiredSignatures: 2,
     version: 0,
     computeUnitsConsumed: 12345,
@@ -52,6 +58,7 @@ describe("transaction payload builder", () => {
       makeFullContext({
         numRequiredSignatures: -1,
         accountKeys: ["a"],
+        resolvedAccounts: [{ address: "a", signer: false, writable: true }],
         numReadonlySignedAccounts: 0,
         numReadonlyUnsignedAccounts: 0,
         instructions: [],
@@ -117,6 +124,10 @@ describe("transaction payload builder", () => {
     const result = buildTransactionPayload(
       makeFullContext({
         accountKeys: ["payer", "system-program"],
+        resolvedAccounts: [
+          { address: "payer", signer: true, writable: true },
+          { address: "system-program", signer: false, writable: false },
+        ],
         numRequiredSignatures: 1,
         numReadonlySignedAccounts: 0,
         numReadonlyUnsignedAccounts: 1,
@@ -148,6 +159,11 @@ describe("transaction payload builder", () => {
     const result = buildTransactionPayload(
       makeFullContext({
         accountKeys: ["signer-a", "signer-b", "other"],
+        resolvedAccounts: [
+          { address: "signer-a", signer: true, writable: true },
+          { address: "signer-b", signer: true, writable: true },
+          { address: "other", signer: false, writable: true },
+        ],
         numRequiredSignatures: 2,
         numReadonlySignedAccounts: 0,
         numReadonlyUnsignedAccounts: 0,
@@ -167,6 +183,12 @@ describe("transaction payload builder", () => {
     const result = buildTransactionPayload(
       makeFullContext({
         accountKeys: ["fee-payer", "cosigner-ro-1", "cosigner-ro-2", "other"],
+        resolvedAccounts: [
+          { address: "fee-payer", signer: true, writable: true },
+          { address: "cosigner-ro-1", signer: true, writable: false },
+          { address: "cosigner-ro-2", signer: true, writable: false },
+          { address: "other", signer: false, writable: true },
+        ],
         numRequiredSignatures: 3,
         numReadonlySignedAccounts: 2,
         numReadonlyUnsignedAccounts: 0,
@@ -187,6 +209,12 @@ describe("transaction payload builder", () => {
     const result = buildTransactionPayload(
       makeFullContext({
         accountKeys: ["signer", "prog-a", "prog-b", "prog-c"],
+        resolvedAccounts: [
+          { address: "signer", signer: true, writable: true },
+          { address: "prog-a", signer: false, writable: false },
+          { address: "prog-b", signer: false, writable: false },
+          { address: "prog-c", signer: false, writable: false },
+        ],
         numRequiredSignatures: 1,
         numReadonlySignedAccounts: 0,
         numReadonlyUnsignedAccounts: 3,
@@ -218,6 +246,11 @@ describe("transaction payload builder", () => {
     const result = buildTransactionPayload(
       makeFullContext({
         accountKeys: ["signer", "prog-a", "prog-b"],
+        resolvedAccounts: [
+          { address: "signer", signer: true, writable: true },
+          { address: "prog-a", signer: false, writable: false },
+          { address: "prog-b", signer: false, writable: false },
+        ],
         numRequiredSignatures: 1,
         numReadonlySignedAccounts: 0,
         numReadonlyUnsignedAccounts: 2,
@@ -265,5 +298,47 @@ describe("transaction payload builder", () => {
     expect(result.entity.fee_lamports).toBe("9007199254740992");
     expect(result.entity.compute_units_consumed).toBe("9007199254740993");
     expect(result.entity.block_time).toBe("9007199254740994");
+  });
+
+  it("uses resolvedAccounts for output accounts", () => {
+    const resolvedAccounts = [
+      { address: "fee-payer", signer: true, writable: true },
+      { address: "readonly-signer", signer: true, writable: false },
+      { address: "writable-nonsigner", signer: false, writable: true },
+      { address: "program", signer: false, writable: false },
+    ];
+    const result = buildTransactionPayload(makeFullContext({ resolvedAccounts }));
+
+    expect(result.entity.accounts).toEqual(resolvedAccounts);
+  });
+
+  it("v0 context with loaded addresses flows through to output", () => {
+    const result = buildTransactionPayload(
+      makeFullContext({
+        accountKeys: ["signer", "program", "alt-w1", "alt-r1"],
+        resolvedAccounts: [
+          { address: "signer", signer: true, writable: true },
+          { address: "program", signer: false, writable: false },
+          { address: "alt-w1", signer: false, writable: true },
+          { address: "alt-r1", signer: false, writable: false },
+        ],
+        numRequiredSignatures: 1,
+        numReadonlySignedAccounts: 0,
+        numReadonlyUnsignedAccounts: 1,
+        instructions: [{ programIdIndex: 1, accounts: [0, 2, 3], data: "abc" }],
+        innerInstructions: null,
+      }),
+    );
+
+    expect(result.entity.accounts).toHaveLength(4);
+    expect(result.entity.accounts[2]).toEqual({ address: "alt-w1", signer: false, writable: true });
+    expect(result.entity.accounts[3]).toEqual({ address: "alt-r1", signer: false, writable: false });
+    expect(result.entity.instructions[0]!.accounts).toEqual(["signer", "alt-w1", "alt-r1"]);
+  });
+
+  it("version 1 flows through to output", () => {
+    const result = buildTransactionPayload(makeFullContext({ version: 1 }));
+
+    expect(result.entity.transaction_version).toBe(1);
   });
 });

--- a/tests/unit/solana/transaction/build-payload.test.ts
+++ b/tests/unit/solana/transaction/build-payload.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+
+import type { TransactionPayloadContext } from "../../../../lib/solana/types";
+import { buildTransactionPayload } from "../../../../lib/solana/transaction/build-payload";
+
+function makeFullContext(overrides: Partial<TransactionPayloadContext> = {}): TransactionPayloadContext {
+  return {
+    signature: "sig",
+    slot: 123,
+    blockTime: 456,
+    status: "success",
+    feeLamports: 5000,
+    accountKeys: ["fee-payer", "readonly-signer", "writable-nonsigner", "program"],
+    numRequiredSignatures: 2,
+    version: 0,
+    computeUnitsConsumed: 12345,
+    err: null,
+    logMessages: ["Program log"],
+    recentBlockhash: "GHtXQBbU",
+    numReadonlySignedAccounts: 1,
+    numReadonlyUnsignedAccounts: 1,
+    confirmationStatus: "finalized",
+    confirmations: "max",
+    instructions: [{ programIdIndex: 3, accounts: [0, 2], data: "abc" }],
+    innerInstructions: [
+      {
+        index: 0,
+        instructions: [{ programIdIndex: 3, accounts: [0], data: "def" }],
+      },
+    ],
+    ...overrides,
+  } as TransactionPayloadContext;
+}
+
+describe("transaction payload builder", () => {
+  it("builds payload with signer slicing", () => {
+    const result = buildTransactionPayload(makeFullContext());
+
+    expect(result.entity).toMatchObject({
+      kind: "transaction",
+      signature: "sig",
+      slot: 123,
+      block_time: 456,
+      status: "success",
+      fee_lamports: 5000,
+      signers: ["fee-payer", "readonly-signer"],
+    });
+  });
+
+  it("handles negative signer counts safely", () => {
+    const result = buildTransactionPayload(
+      makeFullContext({
+        numRequiredSignatures: -1,
+        accountKeys: ["a"],
+        numReadonlySignedAccounts: 0,
+        numReadonlyUnsignedAccounts: 0,
+        instructions: [],
+        innerInstructions: null,
+      }),
+    );
+
+    expect(result.entity).toMatchObject({ signers: [] });
+  });
+
+  it("derives account roles from header", () => {
+    const result = buildTransactionPayload(makeFullContext());
+
+    expect(result.entity.accounts).toEqual([
+      { address: "fee-payer", signer: true, writable: true },
+      { address: "readonly-signer", signer: true, writable: false },
+      { address: "writable-nonsigner", signer: false, writable: true },
+      { address: "program", signer: false, writable: false },
+    ]);
+  });
+
+  it("resolves instruction program_id and accounts to addresses", () => {
+    const result = buildTransactionPayload(makeFullContext());
+
+    expect(result.entity.instructions[0]!).toMatchObject({
+      program_id: "program",
+      accounts: ["fee-payer", "writable-nonsigner"],
+      data: "abc",
+    });
+  });
+
+  it("nests inner instructions under parent", () => {
+    const result = buildTransactionPayload(makeFullContext());
+    const inner = result.entity.instructions[0]!.inner_instructions;
+
+    expect(inner).toEqual([
+      {
+        program_id: "program",
+        accounts: ["fee-payer"],
+        data: "def",
+      },
+    ]);
+  });
+
+  it("returns empty inner_instructions when none match", () => {
+    const result = buildTransactionPayload(makeFullContext({ innerInstructions: null }));
+    const inner = result.entity.instructions[0]!.inner_instructions;
+
+    expect(inner).toEqual([]);
+  });
+
+  it("includes error only when status is failed", () => {
+    const errDetail = { InstructionError: [0, "Custom"] };
+
+    const failed = buildTransactionPayload(makeFullContext({ status: "failed", err: errDetail }));
+    expect(failed.entity.error).toEqual(errDetail);
+
+    const success = buildTransactionPayload(makeFullContext());
+    expect(success.entity.error).toBeNull();
+  });
+
+  it("derives roles for single-signer with one readonly unsigned", () => {
+    const result = buildTransactionPayload(
+      makeFullContext({
+        accountKeys: ["payer", "system-program"],
+        numRequiredSignatures: 1,
+        numReadonlySignedAccounts: 0,
+        numReadonlyUnsignedAccounts: 1,
+        instructions: [],
+        innerInstructions: null,
+      }),
+    );
+
+    expect(result.entity.accounts).toEqual([
+      { address: "payer", signer: true, writable: true },
+      { address: "system-program", signer: false, writable: false },
+    ]);
+  });
+
+  it("includes new scalar fields", () => {
+    const result = buildTransactionPayload(makeFullContext());
+
+    expect(result.entity).toMatchObject({
+      transaction_version: 0,
+      recent_blockhash: "GHtXQBbU",
+      compute_units_consumed: 12345,
+      confirmation_status: "finalized",
+      confirmations: "max",
+      log_messages: ["Program log"],
+    });
+  });
+
+  it("marks all accounts writable when both readonly counts are zero", () => {
+    const result = buildTransactionPayload(
+      makeFullContext({
+        accountKeys: ["signer-a", "signer-b", "other"],
+        numRequiredSignatures: 2,
+        numReadonlySignedAccounts: 0,
+        numReadonlyUnsignedAccounts: 0,
+        instructions: [],
+        innerInstructions: null,
+      }),
+    );
+
+    expect(result.entity.accounts).toEqual([
+      { address: "signer-a", signer: true, writable: true },
+      { address: "signer-b", signer: true, writable: true },
+      { address: "other", signer: false, writable: true },
+    ]);
+  });
+
+  it("derives roles with multiple readonly signers", () => {
+    const result = buildTransactionPayload(
+      makeFullContext({
+        accountKeys: ["fee-payer", "cosigner-ro-1", "cosigner-ro-2", "other"],
+        numRequiredSignatures: 3,
+        numReadonlySignedAccounts: 2,
+        numReadonlyUnsignedAccounts: 0,
+        instructions: [],
+        innerInstructions: null,
+      }),
+    );
+
+    expect(result.entity.accounts).toEqual([
+      { address: "fee-payer", signer: true, writable: true },
+      { address: "cosigner-ro-1", signer: true, writable: false },
+      { address: "cosigner-ro-2", signer: true, writable: false },
+      { address: "other", signer: false, writable: true },
+    ]);
+  });
+
+  it("maps non-contiguous inner instruction groups to correct parents", () => {
+    const result = buildTransactionPayload(
+      makeFullContext({
+        accountKeys: ["signer", "prog-a", "prog-b", "prog-c"],
+        numRequiredSignatures: 1,
+        numReadonlySignedAccounts: 0,
+        numReadonlyUnsignedAccounts: 3,
+        instructions: [
+          { programIdIndex: 1, accounts: [0], data: "ix0" },
+          { programIdIndex: 2, accounts: [0], data: "ix1" },
+          { programIdIndex: 3, accounts: [0], data: "ix2" },
+        ],
+        innerInstructions: [
+          {
+            index: 0,
+            instructions: [{ programIdIndex: 2, accounts: [0], data: "cpi0" }],
+          },
+          {
+            index: 2,
+            instructions: [{ programIdIndex: 1, accounts: [0], data: "cpi2" }],
+          },
+        ],
+      }),
+    );
+
+    const { instructions } = result.entity;
+    expect(instructions[0]!.inner_instructions).toEqual([{ program_id: "prog-b", accounts: ["signer"], data: "cpi0" }]);
+    expect(instructions[1]!.inner_instructions).toEqual([]);
+    expect(instructions[2]!.inner_instructions).toEqual([{ program_id: "prog-a", accounts: ["signer"], data: "cpi2" }]);
+  });
+
+  it("concatenates inner instructions when multiple groups share the same parent index", () => {
+    const result = buildTransactionPayload(
+      makeFullContext({
+        accountKeys: ["signer", "prog-a", "prog-b"],
+        numRequiredSignatures: 1,
+        numReadonlySignedAccounts: 0,
+        numReadonlyUnsignedAccounts: 2,
+        instructions: [{ programIdIndex: 1, accounts: [0], data: "ix0" }],
+        innerInstructions: [
+          {
+            index: 0,
+            instructions: [{ programIdIndex: 2, accounts: [0], data: "cpi-a" }],
+          },
+          {
+            index: 0,
+            instructions: [{ programIdIndex: 1, accounts: [0], data: "cpi-b" }],
+          },
+        ],
+      }),
+    );
+
+    expect(result.entity.instructions[0]!.inner_instructions).toEqual([
+      { program_id: "prog-b", accounts: ["signer"], data: "cpi-a" },
+      { program_id: "prog-a", accounts: ["signer"], data: "cpi-b" },
+    ]);
+  });
+
+  it("returns null error for unknown status", () => {
+    const result = buildTransactionPayload(
+      makeFullContext({
+        status: "unknown",
+        err: null,
+      }),
+    );
+
+    expect(result.entity.status).toBe("unknown");
+    expect(result.entity.error).toBeNull();
+  });
+
+  it("passes string SafeNumeric values through unchanged", () => {
+    const result = buildTransactionPayload(
+      makeFullContext({
+        feeLamports: "9007199254740992",
+        computeUnitsConsumed: "9007199254740993",
+        blockTime: "9007199254740994",
+      }),
+    );
+
+    expect(result.entity.fee_lamports).toBe("9007199254740992");
+    expect(result.entity.compute_units_consumed).toBe("9007199254740993");
+    expect(result.entity.block_time).toBe("9007199254740994");
+  });
+});

--- a/tests/unit/solana/transaction/build-payload.test.ts
+++ b/tests/unit/solana/transaction/build-payload.test.ts
@@ -361,4 +361,41 @@ describe("transaction payload builder", () => {
 
     expect(result.entity.transaction_version).toBe(1);
   });
+
+  it("throws on out-of-bounds instruction account index", () => {
+    expect(() =>
+      buildTransactionPayload(
+        makeFullContext({
+          accountKeys: ["signer"],
+          resolvedAccounts: [staticAccount({ address: "signer", signer: true, writable: true })],
+          numRequiredSignatures: 1,
+          numReadonlySignedAccounts: 0,
+          numReadonlyUnsignedAccounts: 0,
+          instructions: [{ programIdIndex: 5, accounts: [0], data: "abc" }],
+          innerInstructions: null,
+        }),
+      ),
+    ).toThrow("account index 5 out of bounds for 1 keys");
+  });
+
+  it("throws on out-of-bounds inner instruction account index", () => {
+    expect(() =>
+      buildTransactionPayload(
+        makeFullContext({
+          accountKeys: ["signer", "program"],
+          resolvedAccounts: [
+            staticAccount({ address: "signer", signer: true, writable: true }),
+            staticAccount({ address: "program", signer: false, writable: false }),
+          ],
+          numRequiredSignatures: 1,
+          numReadonlySignedAccounts: 0,
+          numReadonlyUnsignedAccounts: 1,
+          instructions: [{ programIdIndex: 1, accounts: [0], data: "abc" }],
+          innerInstructions: [
+            { index: 0, instructions: [{ programIdIndex: 1, accounts: [99], data: "def" }] },
+          ],
+        }),
+      ),
+    ).toThrow("account index 99 out of bounds for 2 keys");
+  });
 });

--- a/tests/unit/solana/transaction/build-payload.test.ts
+++ b/tests/unit/solana/transaction/build-payload.test.ts
@@ -391,9 +391,7 @@ describe("transaction payload builder", () => {
           numReadonlySignedAccounts: 0,
           numReadonlyUnsignedAccounts: 1,
           instructions: [{ programIdIndex: 1, accounts: [0], data: "abc" }],
-          innerInstructions: [
-            { index: 0, instructions: [{ programIdIndex: 1, accounts: [99], data: "def" }] },
-          ],
+          innerInstructions: [{ index: 0, instructions: [{ programIdIndex: 1, accounts: [99], data: "def" }] }],
         }),
       ),
     ).toThrow("account index 99 out of bounds for 2 keys");

--- a/tests/unit/solana/transaction/normalizer.test.ts
+++ b/tests/unit/solana/transaction/normalizer.test.ts
@@ -192,9 +192,9 @@ describe("transaction normalizer", () => {
   });
 
   it("throws on unsupported bigint version", () => {
-    expect(() =>
-      normalizeTransactionProbe("sig", makeFullEnvelope({ version: BigInt(99) }) as never),
-    ).toThrow("unsupported version 99");
+    expect(() => normalizeTransactionProbe("sig", makeFullEnvelope({ version: BigInt(99) }) as never)).toThrow(
+      "unsupported version 99",
+    );
   });
 
   it("normalizes computeUnitsConsumed from bigint", () => {

--- a/tests/unit/solana/transaction/normalizer.test.ts
+++ b/tests/unit/solana/transaction/normalizer.test.ts
@@ -1040,10 +1040,7 @@ describe("transaction normalizer", () => {
   });
 
   it("version 1 flows through to context", () => {
-    const normalized = normalizeTransactionProbe(
-      "sig",
-      makeFullEnvelope({ version: 1 }) as never,
-    );
+    const normalized = normalizeTransactionProbe("sig", makeFullEnvelope({ version: 1 }) as never);
 
     expect(normalized!.version).toBe(1);
     expect(normalized!.resolvedAccounts).toHaveLength(4);

--- a/tests/unit/solana/transaction/normalizer.test.ts
+++ b/tests/unit/solana/transaction/normalizer.test.ts
@@ -853,4 +853,179 @@ describe("transaction normalizer", () => {
 
     expect(normalized!.feeLamports).toBe(String(unsafeNumber));
   });
+
+  it("includes resolvedAccounts in normalized output", () => {
+    const normalized = normalizeTransactionProbe("sig", makeFullEnvelope() as never);
+
+    expect(normalized!.resolvedAccounts).toEqual([
+      { address: "signer-1", signer: true, writable: true },
+      { address: "signer-2", signer: true, writable: false },
+      { address: "program-1", signer: false, writable: true },
+      { address: "readonly-1", signer: false, writable: false },
+    ]);
+  });
+
+  it("merges loadedAddresses for v0 transactions", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        version: 0,
+        meta: {
+          err: null,
+          fee: 5000,
+          loadedAddresses: {
+            writable: ["alt-w1"],
+            readonly: ["alt-r1"],
+          },
+        },
+        transaction: {
+          message: {
+            header: {
+              numRequiredSignatures: 1,
+              numReadonlySignedAccounts: 0,
+              numReadonlyUnsignedAccounts: 1,
+            },
+            accountKeys: ["signer", "program"],
+            instructions: [{ programIdIndex: 1, accounts: [0], data: "3Bxs" }],
+          },
+        },
+      }) as never,
+    );
+
+    expect(normalized!.accountKeys).toEqual(["signer", "program", "alt-w1", "alt-r1"]);
+    expect(normalized!.resolvedAccounts).toEqual([
+      { address: "signer", signer: true, writable: true },
+      { address: "program", signer: false, writable: false },
+      { address: "alt-w1", signer: false, writable: true },
+      { address: "alt-r1", signer: false, writable: false },
+    ]);
+  });
+
+  it("v0 instruction index into loaded address range passes validation", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        version: 0,
+        meta: {
+          err: null,
+          fee: 5000,
+          loadedAddresses: {
+            writable: ["alt-w1"],
+            readonly: ["alt-r1"],
+          },
+        },
+        transaction: {
+          message: {
+            header: {
+              numRequiredSignatures: 1,
+              numReadonlySignedAccounts: 0,
+              numReadonlyUnsignedAccounts: 0,
+            },
+            accountKeys: ["signer"],
+            instructions: [{ programIdIndex: 1, accounts: [0, 2], data: "3Bxs" }],
+          },
+        },
+      }) as never,
+    );
+
+    expect(normalized!.accountKeys).toHaveLength(3);
+  });
+
+  it("v0 instruction index beyond total range still throws", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          version: 0,
+          meta: {
+            err: null,
+            fee: 5000,
+            loadedAddresses: {
+              writable: ["alt-w1"],
+              readonly: [],
+            },
+          },
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 1,
+                numReadonlySignedAccounts: 0,
+                numReadonlyUnsignedAccounts: 0,
+              },
+              accountKeys: ["signer"],
+              instructions: [{ programIdIndex: 5, accounts: [0], data: "3Bxs" }],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("instruction index out of bounds");
+  });
+
+  it("v0 with null loadedAddresses behaves like legacy", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        version: 0,
+        meta: {
+          err: null,
+          fee: 5000,
+          loadedAddresses: null,
+        },
+        transaction: {
+          message: {
+            header: {
+              numRequiredSignatures: 1,
+              numReadonlySignedAccounts: 0,
+              numReadonlyUnsignedAccounts: 0,
+            },
+            accountKeys: ["signer"],
+            instructions: [{ programIdIndex: 0, accounts: [0], data: "3Bxs" }],
+          },
+        },
+      }) as never,
+    );
+
+    expect(normalized!.accountKeys).toEqual(["signer"]);
+  });
+
+  it("version 1 flows through to context", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({ version: 1 }) as never,
+    );
+
+    expect(normalized!.version).toBe(1);
+    expect(normalized!.resolvedAccounts).toHaveLength(4);
+  });
+
+  it("header validation uses static key count not total", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        version: 0,
+        meta: {
+          err: null,
+          fee: 5000,
+          loadedAddresses: {
+            writable: ["alt-w1", "alt-w2", "alt-w3"],
+            readonly: [],
+          },
+        },
+        transaction: {
+          message: {
+            header: {
+              numRequiredSignatures: 2,
+              numReadonlySignedAccounts: 0,
+              numReadonlyUnsignedAccounts: 0,
+            },
+            accountKeys: ["signer-1", "signer-2"],
+            instructions: [{ programIdIndex: 0, accounts: [1], data: "3Bxs" }],
+          },
+        },
+      }) as never,
+    );
+
+    expect(normalized!.accountKeys).toHaveLength(5);
+    expect(normalized!.resolvedAccounts).toHaveLength(5);
+  });
 });

--- a/tests/unit/solana/transaction/normalizer.test.ts
+++ b/tests/unit/solana/transaction/normalizer.test.ts
@@ -149,6 +149,54 @@ describe("transaction normalizer", () => {
     });
   });
 
+  it("coerces bigint version from @solana/kit to number", () => {
+    expect(normalizeTransactionProbe("sig", makeFullEnvelope({ version: BigInt(0) }) as never)).toMatchObject({
+      version: 0,
+    });
+
+    expect(normalizeTransactionProbe("sig", makeFullEnvelope({ version: BigInt(1) }) as never)).toMatchObject({
+      version: 1,
+    });
+  });
+
+  it("v0 resolution triggers correctly with bigint version", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        version: BigInt(0),
+        meta: {
+          err: null,
+          fee: 5000,
+          loadedAddresses: {
+            writable: ["alt-w1"],
+            readonly: ["alt-r1"],
+          },
+        },
+        transaction: {
+          message: {
+            header: {
+              numRequiredSignatures: 1,
+              numReadonlySignedAccounts: 0,
+              numReadonlyUnsignedAccounts: 1,
+            },
+            accountKeys: ["signer", "program"],
+            instructions: [{ programIdIndex: 1, accounts: [0], data: "3Bxs" }],
+          },
+        },
+      }) as never,
+    );
+
+    expect(normalized!.accountKeys).toEqual(["signer", "program", "alt-w1", "alt-r1"]);
+    expect(normalized!.resolvedAccounts).toHaveLength(4);
+    expect(normalized!.resolvedAccounts[2]!.source).toBe("lookupTable");
+  });
+
+  it("throws on unsupported bigint version", () => {
+    expect(() =>
+      normalizeTransactionProbe("sig", makeFullEnvelope({ version: BigInt(99) }) as never),
+    ).toThrow("unsupported version 99");
+  });
+
   it("normalizes computeUnitsConsumed from bigint", () => {
     const normalized = normalizeTransactionProbe(
       "sig",

--- a/tests/unit/solana/transaction/normalizer.test.ts
+++ b/tests/unit/solana/transaction/normalizer.test.ts
@@ -1,0 +1,856 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeTransactionProbe } from "../../../../lib/solana/transaction/normalizer";
+
+function makeFullEnvelope(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    slot: 123,
+    blockTime: 456,
+    version: 0 as const,
+    meta: {
+      err: null,
+      fee: 5000,
+      computeUnitsConsumed: 12345,
+      logMessages: ["Program 111 invoke [1]", "Program 111 success"],
+      innerInstructions: [
+        {
+          index: 0,
+          instructions: [{ programIdIndex: 2, accounts: [0], data: "abc" }],
+        },
+      ],
+    },
+    transaction: {
+      message: {
+        header: {
+          numRequiredSignatures: 2,
+          numReadonlySignedAccounts: 1,
+          numReadonlyUnsignedAccounts: 1,
+        },
+        accountKeys: ["signer-1", { pubkey: "signer-2" }, "program-1", "readonly-1"],
+        recentBlockhash: "GHtXQBbU2vKfGsFqgEz",
+        instructions: [{ programIdIndex: 2, accounts: [0, 1], data: "3Bxs" }],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeStatusEnvelope(overrides: Record<string, unknown> = {}) {
+  return {
+    value: {
+      confirmationStatus: "finalized" as const,
+      confirmations: null,
+      ...overrides,
+    },
+  };
+}
+
+describe("transaction normalizer", () => {
+  it("normalizes mixed account key shapes and successful status", () => {
+    const normalized = normalizeTransactionProbe("sig", makeFullEnvelope() as never);
+
+    expect(normalized).toMatchObject({
+      signature: "sig",
+      slot: 123,
+      blockTime: 456,
+      status: "success",
+      feeLamports: 5000,
+      accountKeys: ["signer-1", "signer-2", "program-1", "readonly-1"],
+      numRequiredSignatures: 2,
+    });
+  });
+
+  it("maps null metadata to unknown status and null fee", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        slot: 999,
+        blockTime: null,
+        meta: null,
+      }) as never,
+    );
+
+    expect(normalized).toMatchObject({
+      status: "unknown",
+      feeLamports: null,
+      computeUnitsConsumed: null,
+      err: null,
+      logMessages: null,
+      innerInstructions: null,
+    });
+  });
+
+  it("returns null for null envelope", () => {
+    expect(normalizeTransactionProbe("sig", null)).toBeNull();
+  });
+
+  it("throws on negative required signature count", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          meta: null,
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: -1,
+                numReadonlySignedAccounts: 0,
+                numReadonlyUnsignedAccounts: 0,
+              },
+              accountKeys: ["signer-1"],
+              instructions: [],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("numRequiredSignatures (-1) out of range for 1 account keys");
+  });
+
+  it("handles bigint slot and fee values", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        slot: BigInt(42),
+        blockTime: BigInt(1000),
+        meta: {
+          err: null,
+          fee: BigInt(5000),
+          computeUnitsConsumed: BigInt(99),
+        },
+      }) as never,
+    );
+
+    expect(normalized).toMatchObject({
+      slot: 42,
+      blockTime: 1000,
+      feeLamports: 5000,
+      computeUnitsConsumed: 99,
+    });
+  });
+
+  it("extracts version field", () => {
+    expect(normalizeTransactionProbe("sig", makeFullEnvelope({ version: 0 }) as never)).toMatchObject({ version: 0 });
+
+    expect(normalizeTransactionProbe("sig", makeFullEnvelope({ version: "legacy" }) as never)).toMatchObject({
+      version: "legacy",
+    });
+
+    expect(normalizeTransactionProbe("sig", makeFullEnvelope({ version: undefined }) as never)).toMatchObject({
+      version: null,
+    });
+  });
+
+  it("normalizes computeUnitsConsumed from bigint", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        meta: { err: null, fee: 5000, computeUnitsConsumed: BigInt(12345) },
+      }) as never,
+    );
+
+    expect(normalized).toMatchObject({ computeUnitsConsumed: 12345 });
+  });
+
+  it("passes through err for failed transactions", () => {
+    const errDetail = { InstructionError: [0, "Custom"] };
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        meta: { err: errDetail, fee: 5000 },
+      }) as never,
+    );
+
+    expect(normalized).toMatchObject({
+      status: "failed",
+      err: errDetail,
+    });
+  });
+
+  it("passes through string err for simple error variants", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        meta: { err: "AccountInUse", fee: 5000 },
+      }) as never,
+    );
+
+    expect(normalized).toMatchObject({
+      status: "failed",
+      err: "AccountInUse",
+    });
+  });
+
+  it("passes through string err for other simple variants", () => {
+    for (const variant of ["BlockhashNotFound", "InsufficientFundsForRent", "AccountLoadedTwice"]) {
+      const normalized = normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          meta: { err: variant, fee: 5000 },
+        }) as never,
+      );
+
+      expect(normalized).toMatchObject({
+        status: "failed",
+        err: variant,
+      });
+    }
+  });
+
+  it("passes through array-shaped err for failed transactions", () => {
+    const arrErr = ["InstructionError", [0, "Custom"]];
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        meta: { err: arrErr, fee: 5000 },
+      }) as never,
+    );
+
+    expect(normalized).toMatchObject({
+      status: "failed",
+      err: arrErr,
+    });
+  });
+
+  it("passes through logMessages array", () => {
+    const logs = ["Program 111 invoke [1]", "Program 111 success"];
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        meta: { err: null, fee: 5000, logMessages: logs },
+      }) as never,
+    );
+
+    expect(normalized!.logMessages).toEqual(logs);
+
+    const withoutLogs = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        meta: { err: null, fee: 5000 },
+      }) as never,
+    );
+
+    expect(withoutLogs!.logMessages).toBeNull();
+  });
+
+  it("extracts recentBlockhash", () => {
+    const normalized = normalizeTransactionProbe("sig", makeFullEnvelope() as never);
+
+    expect(normalized!.recentBlockhash).toBe("GHtXQBbU2vKfGsFqgEz");
+
+    const withoutHash = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        transaction: {
+          message: {
+            header: {
+              numRequiredSignatures: 2,
+              numReadonlySignedAccounts: 1,
+              numReadonlyUnsignedAccounts: 1,
+            },
+            accountKeys: ["signer-1", "signer-2", "program-1", "readonly-1"],
+            instructions: [{ programIdIndex: 2, accounts: [0, 1], data: "3Bxs" }],
+          },
+        },
+      }) as never,
+    );
+
+    expect(withoutHash!.recentBlockhash).toBeNull();
+  });
+
+  it("throws when slot exceeds safe integer range", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          slot: BigInt("9007199254740992"),
+        }) as never,
+      ),
+    ).toThrow("Unexpected transaction probe: slot is not a safe number.");
+  });
+
+  it("preserves unsafe bigint values as strings", () => {
+    const unsafeBigint = BigInt("9007199254740992");
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        meta: {
+          err: null,
+          fee: unsafeBigint,
+          computeUnitsConsumed: unsafeBigint,
+        },
+      }) as never,
+    );
+
+    expect(normalized!.feeLamports).toBe("9007199254740992");
+    expect(normalized!.computeUnitsConsumed).toBe("9007199254740992");
+  });
+
+  it("throws when all signers would be readonly", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 2,
+                numReadonlySignedAccounts: 2,
+                numReadonlyUnsignedAccounts: 0,
+              },
+              accountKeys: ["a", "b", "c"],
+              instructions: [],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("readonly counts (signed=2, unsigned=0) exceed available accounts");
+  });
+
+  it("throws when signer count exceeds account keys length", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 5,
+                numReadonlySignedAccounts: 0,
+                numReadonlyUnsignedAccounts: 0,
+              },
+              accountKeys: ["a", "b"],
+              instructions: [],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("numRequiredSignatures (5) out of range for 2 account keys");
+  });
+
+  it("throws when readonly unsigned count exceeds non-signer accounts", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 1,
+                numReadonlySignedAccounts: 0,
+                numReadonlyUnsignedAccounts: 5,
+              },
+              accountKeys: ["a", "b", "c"],
+              instructions: [],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("readonly counts (signed=0, unsigned=5) exceed available accounts");
+  });
+
+  it("validates readonly header counts", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 1,
+                numReadonlySignedAccounts: -1,
+                numReadonlyUnsignedAccounts: 0,
+              },
+              accountKeys: ["signer-1"],
+              instructions: [],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("Unexpected transaction probe:");
+
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 1,
+                numReadonlySignedAccounts: 0,
+                numReadonlyUnsignedAccounts: -1,
+              },
+              accountKeys: ["signer-1"],
+              instructions: [],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("Unexpected transaction probe:");
+  });
+
+  it("passes through instructions and innerInstructions", () => {
+    const normalized = normalizeTransactionProbe("sig", makeFullEnvelope() as never);
+
+    expect(normalized!.instructions).toEqual([{ programIdIndex: 2, accounts: [0, 1], data: "3Bxs" }]);
+    expect(normalized!.innerInstructions).toEqual([
+      {
+        index: 0,
+        instructions: [{ programIdIndex: 2, accounts: [0], data: "abc" }],
+      },
+    ]);
+  });
+
+  it("maps finalized status to max confirmations", () => {
+    const normalized = normalizeTransactionProbe("sig", makeFullEnvelope() as never, makeStatusEnvelope());
+
+    expect(normalized).toMatchObject({
+      confirmationStatus: "finalized",
+      confirmations: "max",
+    });
+  });
+
+  it("passes through numeric confirmations for non-finalized", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope() as never,
+      makeStatusEnvelope({
+        confirmationStatus: "confirmed",
+        confirmations: 42,
+      }),
+    );
+
+    expect(normalized).toMatchObject({
+      confirmationStatus: "confirmed",
+      confirmations: 42,
+    });
+  });
+
+  it("defaults confirmation fields to null when status envelope is null", () => {
+    const normalized = normalizeTransactionProbe("sig", makeFullEnvelope() as never, null);
+
+    expect(normalized).toMatchObject({
+      confirmationStatus: null,
+      confirmations: null,
+    });
+  });
+
+  it("defaults confirmation fields to null when status envelope is omitted", () => {
+    const normalized = normalizeTransactionProbe("sig", makeFullEnvelope() as never);
+
+    expect(normalized).toMatchObject({
+      confirmationStatus: null,
+      confirmations: null,
+    });
+  });
+
+  it("passes through numeric confirmations for processed status", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope() as never,
+      makeStatusEnvelope({
+        confirmationStatus: "processed",
+        confirmations: 3,
+      }),
+    );
+
+    expect(normalized).toMatchObject({
+      confirmationStatus: "processed",
+      confirmations: 3,
+    });
+  });
+
+  it("converts bigint confirmations for confirmed status", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope() as never,
+      makeStatusEnvelope({
+        confirmationStatus: "confirmed",
+        confirmations: BigInt(10),
+      }),
+    );
+
+    expect(normalized).toMatchObject({
+      confirmationStatus: "confirmed",
+      confirmations: 10,
+    });
+  });
+
+  it("converts bigint confirmations directly to number", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope() as never,
+      makeStatusEnvelope({
+        confirmationStatus: "confirmed",
+        confirmations: BigInt(25),
+      }),
+    );
+
+    expect(normalized).toMatchObject({
+      confirmationStatus: "confirmed",
+      confirmations: 25,
+    });
+  });
+
+  it("throws on out-of-bounds programIdIndex in instructions", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          meta: { err: null, fee: 5000 },
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 1,
+                numReadonlySignedAccounts: 0,
+                numReadonlyUnsignedAccounts: 0,
+              },
+              accountKeys: ["signer-1"],
+              recentBlockhash: "GHtX",
+              instructions: [{ programIdIndex: 5, accounts: [0], data: "abc" }],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("Unexpected transaction probe:");
+  });
+
+  it("throws on out-of-bounds account index in instructions", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          meta: { err: null, fee: 5000 },
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 1,
+                numReadonlySignedAccounts: 0,
+                numReadonlyUnsignedAccounts: 0,
+              },
+              accountKeys: ["signer-1"],
+              recentBlockhash: "GHtX",
+              instructions: [{ programIdIndex: 0, accounts: [0, 99], data: "abc" }],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("Unexpected transaction probe:");
+  });
+
+  it("throws on out-of-bounds index in inner instructions", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          meta: {
+            err: null,
+            fee: 5000,
+            innerInstructions: [
+              {
+                index: 0,
+                instructions: [{ programIdIndex: 99, accounts: [0], data: "abc" }],
+              },
+            ],
+          },
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 1,
+                numReadonlySignedAccounts: 0,
+                numReadonlyUnsignedAccounts: 0,
+              },
+              accountKeys: ["signer-1"],
+              recentBlockhash: "GHtX",
+              instructions: [{ programIdIndex: 0, accounts: [0], data: "abc" }],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("Unexpected transaction probe:");
+  });
+
+  it("throws on negative programIdIndex in instructions", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          meta: { err: null, fee: 5000 },
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 1,
+                numReadonlySignedAccounts: 0,
+                numReadonlyUnsignedAccounts: 0,
+              },
+              accountKeys: ["signer-1"],
+              recentBlockhash: "GHtX",
+              instructions: [{ programIdIndex: -1, accounts: [0], data: "abc" }],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("instruction index out of bounds (programIdIndex=-1");
+  });
+
+  it("throws on negative account index in inner instructions", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          meta: {
+            err: null,
+            fee: 5000,
+            innerInstructions: [
+              {
+                index: 0,
+                instructions: [{ programIdIndex: 0, accounts: [-1], data: "abc" }],
+              },
+            ],
+          },
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 1,
+                numReadonlySignedAccounts: 0,
+                numReadonlyUnsignedAccounts: 0,
+              },
+              accountKeys: ["signer-1"],
+              recentBlockhash: "GHtX",
+              instructions: [{ programIdIndex: 0, accounts: [0], data: "abc" }],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("inner instruction index out of bounds (programIdIndex=0, accounts=[-1]");
+  });
+
+  it("normalizes NaN blockTime to null", () => {
+    const normalized = normalizeTransactionProbe("sig", makeFullEnvelope({ blockTime: NaN }) as never);
+
+    expect(normalized!.blockTime).toBeNull();
+  });
+
+  it("rejects zero required signatures", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          meta: null,
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 0,
+                numReadonlySignedAccounts: 0,
+                numReadonlyUnsignedAccounts: 0,
+              },
+              accountKeys: ["a"],
+              instructions: [],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("numRequiredSignatures (0) out of range");
+  });
+
+  it("defaults confirmations to null for non-finalized with null count", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope() as never,
+      makeStatusEnvelope({
+        confirmationStatus: "confirmed",
+        confirmations: null,
+      }),
+    );
+
+    expect(normalized).toMatchObject({
+      confirmationStatus: "confirmed",
+      confirmations: null,
+    });
+  });
+
+  it("maps unrecognized confirmation status to null while preserving confirmations", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope() as never,
+      makeStatusEnvelope({
+        confirmationStatus: "optimistic" as never,
+        confirmations: 5,
+      }),
+    );
+
+    expect(normalized).toMatchObject({
+      confirmationStatus: null,
+      confirmations: 5,
+    });
+  });
+
+  it("throws when inner instruction group index exceeds instruction count", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          meta: {
+            err: null,
+            fee: 5000,
+            innerInstructions: [
+              {
+                index: 5,
+                instructions: [{ programIdIndex: 0, accounts: [0], data: "abc" }],
+              },
+            ],
+          },
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 1,
+                numReadonlySignedAccounts: 0,
+                numReadonlyUnsignedAccounts: 0,
+              },
+              accountKeys: ["signer-1"],
+              recentBlockhash: "GHtX",
+              instructions: [{ programIdIndex: 0, accounts: [0], data: "abc" }],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("inner instruction group index (5) out of bounds for 1 instructions");
+  });
+
+  it("throws when inner instruction group index equals instruction count (off-by-one)", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          meta: {
+            err: null,
+            fee: 5000,
+            innerInstructions: [
+              {
+                index: 1,
+                instructions: [{ programIdIndex: 0, accounts: [0], data: "abc" }],
+              },
+            ],
+          },
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 1,
+                numReadonlySignedAccounts: 0,
+                numReadonlyUnsignedAccounts: 0,
+              },
+              accountKeys: ["signer-1"],
+              recentBlockhash: "GHtX",
+              instructions: [{ programIdIndex: 0, accounts: [0], data: "abc" }],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("inner instruction group index (1) out of bounds for 1 instructions");
+  });
+
+  it("throws when inner instruction group index is negative", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          meta: {
+            err: null,
+            fee: 5000,
+            innerInstructions: [
+              {
+                index: -1,
+                instructions: [{ programIdIndex: 0, accounts: [0], data: "abc" }],
+              },
+            ],
+          },
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 1,
+                numReadonlySignedAccounts: 0,
+                numReadonlyUnsignedAccounts: 0,
+              },
+              accountKeys: ["signer-1"],
+              recentBlockhash: "GHtX",
+              instructions: [{ programIdIndex: 0, accounts: [0], data: "abc" }],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("inner instruction group index (-1) out of bounds");
+  });
+
+  it("normalizes Infinity blockTime to null", () => {
+    const normalized = normalizeTransactionProbe("sig", makeFullEnvelope({ blockTime: Infinity }) as never);
+
+    expect(normalized!.blockTime).toBeNull();
+  });
+
+  it("normalizes -Infinity fee to null", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        meta: { err: null, fee: -Infinity },
+      }) as never,
+    );
+
+    expect(normalized!.feeLamports).toBeNull();
+  });
+
+  it("rejects empty account keys with zero signatures", () => {
+    expect(() =>
+      normalizeTransactionProbe(
+        "sig",
+        makeFullEnvelope({
+          meta: null,
+          transaction: {
+            message: {
+              header: {
+                numRequiredSignatures: 0,
+                numReadonlySignedAccounts: 0,
+                numReadonlyUnsignedAccounts: 0,
+              },
+              accountKeys: [],
+              instructions: [],
+            },
+          },
+        }) as never,
+      ),
+    ).toThrow("numRequiredSignatures (0) out of range");
+  });
+
+  it("defaults confirmation fields when status envelope has null value", () => {
+    const normalized = normalizeTransactionProbe("sig", makeFullEnvelope() as never, { value: null });
+
+    expect(normalized).toMatchObject({
+      confirmationStatus: null,
+      confirmations: null,
+    });
+  });
+
+  it("stringifies unrecognized error shape", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        meta: { err: 42, fee: 5000 },
+      }) as never,
+    );
+
+    expect(normalized).toMatchObject({
+      status: "failed",
+      err: "42",
+    });
+  });
+
+  it("stringifies unsafe finite number values", () => {
+    const unsafeNumber = Number.MAX_SAFE_INTEGER + 1;
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        meta: { err: null, fee: unsafeNumber },
+      }) as never,
+    );
+
+    expect(normalized!.feeLamports).toBe(String(unsafeNumber));
+  });
+});

--- a/tests/unit/solana/transaction/normalizer.test.ts
+++ b/tests/unit/solana/transaction/normalizer.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 
+import type { AccountRole, ResolvedAccount } from "../../../../lib/solana/types";
 import { normalizeTransactionProbe } from "../../../../lib/solana/transaction/normalizer";
+
+function staticAccount(role: AccountRole): ResolvedAccount {
+  return { ...role, source: "static" };
+}
+
+function lookupTableAccount(role: AccountRole, lookupTableAddress?: string): ResolvedAccount {
+  return { ...role, source: "lookupTable", ...(lookupTableAddress != null && { lookupTableAddress }) };
+}
 
 function makeFullEnvelope(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
@@ -854,14 +863,14 @@ describe("transaction normalizer", () => {
     expect(normalized!.feeLamports).toBe(String(unsafeNumber));
   });
 
-  it("includes resolvedAccounts in normalized output", () => {
+  it("includes resolvedAccounts with source in normalized output", () => {
     const normalized = normalizeTransactionProbe("sig", makeFullEnvelope() as never);
 
     expect(normalized!.resolvedAccounts).toEqual([
-      { address: "signer-1", signer: true, writable: true },
-      { address: "signer-2", signer: true, writable: false },
-      { address: "program-1", signer: false, writable: true },
-      { address: "readonly-1", signer: false, writable: false },
+      staticAccount({ address: "signer-1", signer: true, writable: true }),
+      staticAccount({ address: "signer-2", signer: true, writable: false }),
+      staticAccount({ address: "program-1", signer: false, writable: true }),
+      staticAccount({ address: "readonly-1", signer: false, writable: false }),
     ]);
   });
 
@@ -894,11 +903,53 @@ describe("transaction normalizer", () => {
 
     expect(normalized!.accountKeys).toEqual(["signer", "program", "alt-w1", "alt-r1"]);
     expect(normalized!.resolvedAccounts).toEqual([
-      { address: "signer", signer: true, writable: true },
-      { address: "program", signer: false, writable: false },
-      { address: "alt-w1", signer: false, writable: true },
-      { address: "alt-r1", signer: false, writable: false },
+      staticAccount({ address: "signer", signer: true, writable: true }),
+      staticAccount({ address: "program", signer: false, writable: false }),
+      lookupTableAccount({ address: "alt-w1", signer: false, writable: true }),
+      lookupTableAccount({ address: "alt-r1", signer: false, writable: false }),
     ]);
+  });
+
+  it("tags loaded accounts with their lookup table address", () => {
+    const normalized = normalizeTransactionProbe(
+      "sig",
+      makeFullEnvelope({
+        version: 0,
+        meta: {
+          err: null,
+          fee: 5000,
+          loadedAddresses: {
+            writable: ["alt-w1", "alt-w2"],
+            readonly: ["alt-r1"],
+          },
+        },
+        transaction: {
+          message: {
+            header: {
+              numRequiredSignatures: 1,
+              numReadonlySignedAccounts: 0,
+              numReadonlyUnsignedAccounts: 0,
+            },
+            accountKeys: ["signer"],
+            instructions: [{ programIdIndex: 0, accounts: [0], data: "3Bxs" }],
+            addressTableLookups: [
+              { accountKey: "ALT-A", writableIndexes: [0], readonlyIndexes: [1] },
+              { accountKey: "ALT-B", writableIndexes: [2], readonlyIndexes: [] },
+            ],
+          },
+        },
+      }) as never,
+    );
+
+    expect(normalized!.resolvedAccounts[1]).toEqual(
+      lookupTableAccount({ address: "alt-w1", signer: false, writable: true }, "ALT-A"),
+    );
+    expect(normalized!.resolvedAccounts[2]).toEqual(
+      lookupTableAccount({ address: "alt-w2", signer: false, writable: true }, "ALT-B"),
+    );
+    expect(normalized!.resolvedAccounts[3]).toEqual(
+      lookupTableAccount({ address: "alt-r1", signer: false, writable: false }, "ALT-A"),
+    );
   });
 
   it("v0 instruction index into loaded address range passes validation", () => {


### PR DESCRIPTION
## Description

This is part of a multi-PR to port the `inspect_entity` tool from `solana-explorer-mcp` into `solana-mcp-official`, giving the MCP server on-chain data inspection alongside its existing documentation/RAG tools.


## Roadmap

- [x] **Step 0 — Infrastructure Prep**: Pin MCP SDK `1.27.1`, bump `maxDuration` to 120, bump `@vercel/mcp-adapter` to `^1.0.0`
- [x] **Step 1 — Foundation**: `lib/config.ts` (unified config, Zod v3), `lib/observability/logger.ts` (minimal JSON logger), `lib/solana/types.ts`, `constants.ts`, `parse-helpers.ts`, `errors.ts`, `timeout.ts` + unit tests
- [x] **Step 2 — RPC Layer + Account Normalizer**: `lib/solana/rpc.ts`, `account-normalizer.ts` + dep `@solana/kit ^6.4.0` + tests
- [x] **Step 3 — Classifier + Account-Kind Builders + Router**: `inspect-entity-classifier.ts`, `inspect-entity-account-router.ts`, 18 account-kind builders under `lib/solana/account-kinds/` + tests
- [x] **Step 4 — Wire Up Tool (Accounts, Stub Enrichment)**: `lib/solana/inspect-entity.ts`, `lib/tools/inspectEntityTools.ts`, expand `SolanaTool` type with `annotations` + `ZodObject` support, register in `lib/index.ts` + integration tests
- [x] **Step 5 — Transactions + All Enrichment Resolvers**: Transaction normaliser + payload builder, all 15 resolver files under `lib/solana/resolvers/`, `anchor.ts`, embedded IDLs + deps `@coral-xyz/anchor ^0.32.1`, `@solana-program/program-metadata ^0.5.1` + tests
- [ ] **Step 6 — Analytics, Config Migration, Polish**: Analytics logging for inspect tool, migrate remaining `process.env` to config, E2E tests, `.env.example` update

## Changes in this PR

### Step(s) covered

Step 5 / core + metaplex