### PR TITLE
fix(inkeep): force chat completions endpoint

### DIFF
--- a/lib/services/inkeep/index.ts
+++ b/lib/services/inkeep/index.ts
@@ -7,4 +7,6 @@ const inkeep = process.env.INKEEP_API_KEY
     })
   : null;
 
-export const inkeepRagModel = inkeep?.("inkeep-rag") ?? null;
+// Force chat completions endpoint — @ai-sdk/openai v3 defaults to /v1/responses
+// (OpenAI's Responses API) which Inkeep does not implement.
+export const inkeepRagModel = inkeep?.chat("inkeep-rag") ?? null;


### PR DESCRIPTION
## Summary
- `@ai-sdk/openai` v3 (via `ai` v6) defaults to OpenAI's new `/v1/responses` Responses API. Inkeep only implements `/v1/chat/completions`, so every prod tool call has returned `Not Found` since `~2026-04-09` (14 days of silent prod failure).
- Fix: switch `inkeep("inkeep-rag")` → `inkeep.chat("inkeep-rag")` so the SDK routes to the chat completions endpoint.

## Verification
- Direct curl against Inkeep:
  - `POST /v1/chat/completions` → HTTP 200, valid response
  - `POST /v1/responses` → HTTP 404 "Not Found"
- `pnpm typecheck && pnpm test && pnpm lint` — 227 tests pass.