### PR TITLE
feat(vector-search): make top-k configurable, default 20

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,7 @@ DATABRICKS_TOKEN=
 DATABRICKS_CLIENT_ID=
 DATABRICKS_CLIENT_SECRET=
 DATABRICKS_VS_INDEX=<catalog>.<schema>.docs_chunks_idx
+# Optional: top-K chunks returned by searchDocs. Default 20, capped at 50.
+DATABRICKS_VS_K=
 DATABRICKS_WAREHOUSE_ID=<warehouse-id>
 DATABRICKS_ANALYTICS_SCHEMA=<catalog>.<schema>

--- a/lib/services/databricks/vectorSearch.ts
+++ b/lib/services/databricks/vectorSearch.ts
@@ -24,8 +24,18 @@ interface VsQueryResponse {
 const REQUESTED_COLUMNS = ["id", "url", "title", "source_id", "content"] as const;
 
 const OVERSAMPLE_MULTIPLIER = 3;
+const DEFAULT_K = 20;
+const MAX_K = 50;
 
-export async function searchDocs(query: string, k = 8): Promise<DocChunk[]> {
+function resolveK(k?: number): number {
+  if (typeof k === "number" && Number.isInteger(k) && k > 0) return Math.min(k, MAX_K);
+  const envK = Number(process.env.DATABRICKS_VS_K);
+  if (Number.isInteger(envK) && envK > 0) return Math.min(envK, MAX_K);
+  return DEFAULT_K;
+}
+
+export async function searchDocs(query: string, k?: number): Promise<DocChunk[]> {
+  const topK = resolveK(k);
   const index = process.env.DATABRICKS_VS_INDEX;
   if (!isDatabricksConfigured() || !index) {
     console.warn("[vectorSearch] DATABRICKS_VS_INDEX (or host/token) not set — retrieval disabled");
@@ -35,7 +45,7 @@ export async function searchDocs(query: string, k = 8): Promise<DocChunk[]> {
   const body = {
     query_text: query,
     columns: [...REQUESTED_COLUMNS],
-    num_results: k * OVERSAMPLE_MULTIPLIER,
+    num_results: topK * OVERSAMPLE_MULTIPLIER,
   };
 
   const res = await dbxFetch<VsQueryResponse>(`/api/2.0/vector-search/indexes/${index}/query`, {
@@ -50,7 +60,7 @@ export async function searchDocs(query: string, k = 8): Promise<DocChunk[]> {
   // Sort score-descending before dedupe so the highest-scored chunk per URL
   // is kept, independent of any ordering guarantee from the Databricks API.
   chunks.sort((a, b) => b.score - a.score);
-  return dedupeByUrl(chunks).slice(0, k);
+  return dedupeByUrl(chunks).slice(0, topK);
 }
 
 function dedupeByUrl(chunks: DocChunk[]): DocChunk[] {

--- a/lib/tools/generalSolanaTools.ts
+++ b/lib/tools/generalSolanaTools.ts
@@ -7,7 +7,7 @@ import { formatChunksAsMarkdown } from "./formatChunks.js";
 import type { SolanaTool } from "./types";
 
 async function answerViaDatabricks(tool: "Solana_Expert__Ask_For_Help" | "Solana_Documentation_Search", query: string) {
-  const chunks = await searchDocs(query, 8);
+  const chunks = await searchDocs(query);
   const text = formatChunksAsMarkdown(query, chunks);
 
   await logAnalytics({

--- a/tests/unit/databricks.vectorSearch.test.ts
+++ b/tests/unit/databricks.vectorSearch.test.ts
@@ -28,6 +28,7 @@ describe("databricks vectorSearch", () => {
     delete process.env.DATABRICKS_HOST;
     delete process.env.DATABRICKS_TOKEN;
     delete process.env.DATABRICKS_VS_INDEX;
+    delete process.env.DATABRICKS_VS_K;
   });
 
   it("returns [] and warns when index env missing, without calling fetch", async () => {
@@ -188,6 +189,46 @@ describe("databricks vectorSearch", () => {
     const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");
     const chunks = await searchDocs("x", 5);
     expect(chunks.map(c => c.id)).toEqual(["id-1", "id-2"]);
+  });
+
+  it("defaults k to 20 (oversampled num_results=60) when no arg or env", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        manifest: { columns: [{ name: "id" }, { name: "score" }] },
+        result: { data_array: [] },
+      }),
+    );
+    const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");
+    await searchDocs("hello");
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string).num_results).toBe(60);
+  });
+
+  it("reads DATABRICKS_VS_K env when arg omitted", async () => {
+    process.env.DATABRICKS_VS_K = "12";
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        manifest: { columns: [{ name: "id" }, { name: "score" }] },
+        result: { data_array: [] },
+      }),
+    );
+    const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");
+    await searchDocs("hello");
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string).num_results).toBe(36); // 12 * 3
+  });
+
+  it("caps k at 50 regardless of arg or env", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        manifest: { columns: [{ name: "id" }, { name: "score" }] },
+        result: { data_array: [] },
+      }),
+    );
+    const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");
+    await searchDocs("hello", 9999);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string).num_results).toBe(150); // 50 * 3
   });
 
   it("handles empty result set", async () => {

--- a/tests/unit/generalSolanaTools.test.ts
+++ b/tests/unit/generalSolanaTools.test.ts
@@ -132,7 +132,7 @@ describe("createSolanaTools", () => {
 
       const result = await askTool.func({ question: "what is a PDA?" });
 
-      expect(searchDocsMock).toHaveBeenCalledWith("what is a PDA?", 8);
+      expect(searchDocsMock).toHaveBeenCalledWith("what is a PDA?");
       expect(generateTextMock).not.toHaveBeenCalled();
       const text = (result as { content: [{ text: string }] }).content[0].text;
       expect(text).toContain("PDA Basics");
@@ -157,7 +157,7 @@ describe("createSolanaTools", () => {
 
       const result = await searchTool.func({ query: "pda seeds" });
 
-      expect(searchDocsMock).toHaveBeenCalledWith("pda seeds", 8);
+      expect(searchDocsMock).toHaveBeenCalledWith("pda seeds");
       const text = (result as { content: [{ text: string }] }).content[0].text;
       expect(text).toContain("PDA Basics");
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "resolveJsonModule": true
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "eval"]
 }


### PR DESCRIPTION
## Summary
- Bump default `searchDocs` top-k from 8 → **20** based on A/B eval (Inkeep returns 20-90 docs per query; we returned 8 → 0.80 vs 0.92 keyword hit rate).
- New `DATABRICKS_VS_K` env var lets operators tune without redeploy; clamped to `[1, 50]`.
- `searchDocs(query)` (no `k` arg) resolves in order: arg → env → 20. Existing explicit-`k` callers unaffected.
- Tool handlers drop the hard-coded `searchDocs(q, 8)` so they inherit the default.

## Test Plan
- `pnpm typecheck && pnpm test && pnpm lint` — 230 tests pass (3 new cases: default, env override, cap at 50).
- Post-deploy: rerun `eval/run.ts` and expect keyword hit rate ≥ 0.85.

## Notes
- `tsconfig.json` now excludes `eval/` (local-only harness) so typecheck doesn't trip on its ESM `import.meta.url`.