### PR TITLE
fix(build): invoke gen:sources directly to support npm-only build env

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "gen:sources": "node scripts/build-sources.mjs",
     "start": "vercel dev",
-    "dev:local": "pnpm gen:sources && vercel dev --local",
-    "build": "pnpm gen:sources && tsup",
+    "dev:local": "node scripts/build-sources.mjs && vercel dev --local",
+    "build": "node scripts/build-sources.mjs && tsup",
     "start:app": "node dist/start.js",
     "test": "pnpm test:integration",
     "test:integration": "pnpm gen:sources && vitest run tests/integration.test.ts tests/unit/",


### PR DESCRIPTION
## Summary

Hotfix for prod app deploy. The build script previously chained `pnpm gen:sources && tsup`, but Databricks Apps' build environment only has `npm` in PATH. App build fails with `sh: 1: pnpm: not found`.

Switch `build` and `dev:local` to invoke the codegen entrypoint via `node scripts/build-sources.mjs` directly — package-manager agnostic. Other test/typecheck scripts unchanged because they only run in CI / local where pnpm is present.

Verified via `pnpm build` locally — `dist/start.js` 84.31 KB.

## Test plan

- [x] `pnpm build` clean (gen:sources runs, tsup completes)
- [x] CI checks pass on this PR
- [ ] After merge: `just deploy` succeeds end-to-end (currently fails app build step)