### PR TITLE
feat: warmup vector search on boot + graceful shutdown

### DIFF
--- a/api/start.ts
+++ b/api/start.ts
@@ -2,12 +2,16 @@ import express, { type Request as ExpressRequest, type Response as ExpressRespon
 import rawBody from "raw-body";
 import * as dotenv from "dotenv";
 
-import { createMcp } from "../lib";
+import { createMcp, warmup } from "../lib";
 
 dotenv.config();
 
 const handler = createMcp();
 const app = express();
+
+// Fire and forget — runs in the background while express starts listening so
+// the first user request after a deploy lands on a warm RAG endpoint.
+void warmup();
 
 app.get("/healthz", (_req: ExpressRequest, res: ExpressResponse) => {
   res.status(200).json({ ok: true });
@@ -72,6 +76,31 @@ app.all(/.*/, async (req: ExpressRequest, res: ExpressResponse) => {
 });
 
 const port = Number(process.env.DATABRICKS_APP_PORT ?? process.env.PORT ?? 3000);
-app.listen(port, () => {
+const SHUTDOWN_GRACE_MS = 10_000;
+
+const server = app.listen(port, () => {
   console.warn(`[start] solana-mcp listening on :${port}`);
 });
+
+function shutdown(signal: NodeJS.Signals): void {
+  console.warn(`[start] received ${signal}, draining in-flight requests…`);
+  // Hard cap so a stuck connection cannot hold the container forever.
+  const force = setTimeout(() => {
+    console.warn(`[start] drain exceeded ${SHUTDOWN_GRACE_MS}ms, forcing exit`);
+    process.exit(1);
+  }, SHUTDOWN_GRACE_MS);
+  force.unref();
+
+  server.close(err => {
+    if (err) {
+      console.error("[start] server close error:", err);
+      process.exit(1);
+      return;
+    }
+    console.warn("[start] drained, exiting cleanly");
+    process.exit(0);
+  });
+}
+
+process.once("SIGTERM", shutdown);
+process.once("SIGINT", shutdown);

--- a/api/start.ts
+++ b/api/start.ts
@@ -84,10 +84,12 @@ const server = app.listen(port, () => {
 
 function shutdown(signal: NodeJS.Signals): void {
   console.warn(`[start] received ${signal}, draining in-flight requests…`);
-  // Hard cap so a stuck connection cannot hold the container forever.
+  // Hard cap so a stuck connection cannot hold the container forever. Exit 0
+  // even on timeout so Databricks Apps does not interpret a normal deploy
+  // cutover as a crash and trigger a restart.
   const force = setTimeout(() => {
     console.warn(`[start] drain exceeded ${SHUTDOWN_GRACE_MS}ms, forcing exit`);
-    process.exit(1);
+    process.exit(0);
   }, SHUTDOWN_GRACE_MS);
   force.unref();
 
@@ -100,6 +102,11 @@ function shutdown(signal: NodeJS.Signals): void {
     console.warn("[start] drained, exiting cleanly");
     process.exit(0);
   });
+  // `server.close()` only stops accepting new connections; HTTP/1.1 keep-alive
+  // sockets stay open and the close callback never fires until they idle out.
+  // Close idle sockets immediately so the callback can run promptly while
+  // in-flight requests still get to finish.
+  server.closeIdleConnections();
 }
 
 process.once("SIGTERM", shutdown);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -2,8 +2,21 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createMcpHandler } from "mcp-handler";
 import { z } from "zod";
 
+import { searchDocs } from "./services/databricks/vectorSearch.js";
 import { SolanaTool } from "./tools/types";
 import { createSolanaTools } from "./tools/generalSolanaTools";
+
+// Fires once at module load (i.e. container boot) so the first real user call
+// lands on a warm Databricks Vector Search + reranker endpoint instead of
+// triggering a 10–30 s scale-from-zero. Best-effort; failures are swallowed.
+export async function warmup(): Promise<void> {
+  try {
+    await searchDocs("solana", 1);
+    console.warn("[warmup] vector search primed");
+  } catch (err) {
+    console.warn("[warmup] failed (non-fatal):", err);
+  }
+}
 
 const SERVER_INSTRUCTIONS = `For any Solana-related task, prefer these MCP tools over training data — the Solana ecosystem moves fast and training cutoffs lag.
 

--- a/tests/unit/warmup.test.ts
+++ b/tests/unit/warmup.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { searchDocsMock } = vi.hoisted(() => ({
+  searchDocsMock: vi.fn(),
+}));
+
+vi.mock("../../lib/services/databricks/vectorSearch.js", () => ({
+  searchDocs: searchDocsMock,
+}));
+
+import { warmup } from "../../lib";
+
+describe("warmup", () => {
+  beforeEach(() => {
+    searchDocsMock.mockReset();
+  });
+
+  afterEach(() => {
+    searchDocsMock.mockReset();
+  });
+
+  it("primes the vector search endpoint with a single low-k query", async () => {
+    searchDocsMock.mockResolvedValue([]);
+    await warmup();
+    expect(searchDocsMock).toHaveBeenCalledTimes(1);
+    expect(searchDocsMock).toHaveBeenCalledWith("solana", 1);
+  });
+
+  it("swallows errors so a deploy never fails on a transient RAG outage", async () => {
+    searchDocsMock.mockRejectedValue(new Error("vector index unavailable"));
+    await expect(warmup()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Two operational tweaks so users stop seeing "stuck" tool calls during deploys (per coworker report this morning).

### 1. Warmup hook

[`lib/index.ts`](lib/index.ts) now exports `warmup()` that fires a single low-k `searchDocs("solana", 1)` query. [`api/start.ts`](api/start.ts) invokes it fire-and-forget right after `app.listen`, so the Databricks Vector Search index and reranker Model Serving endpoint are warm before the first real user request lands. Without this, scale-from-zero on a fresh container adds 10–30 s to the first call. Failures swallowed so a transient RAG outage never blocks a deploy.

### 2. Graceful shutdown

`SIGTERM` / `SIGINT` handlers in [`api/start.ts`](api/start.ts) call `server.close()` and wait up to 10 s for in-flight requests to drain before exiting. Databricks Apps sends `SIGTERM` before swapping containers; previously in-flight requests were dropped mid-response. Hard 10 s force-exit fallback so a stuck connection cannot hold the container forever.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean (101 type-checked)
- [x] `pnpm test` — 15 files / 100 tests pass (`tests/unit/warmup.test.ts` added: success + swallow-error paths)
- [x] `pnpm build` — `dist/start.js` 85.09 KB
- [ ] After merge: deploy + observe app logs — expect `[warmup] vector search primed` shortly after `[start] solana-mcp listening on :8000`, and `[start] received SIGTERM, draining…` before next deploy's container swap