### PR TITLE
fix(sources): restrict solana-docs crawl to /docs/ + /developers/ trees

### DIFF
--- a/ingestion/sources.yaml
+++ b/ingestion/sources.yaml
@@ -54,9 +54,6 @@ sources:
     primary_url: https://solana.com/docs
     start_urls:
       - https://solana.com/docs
-    # Without this, the BFS crawl picks up the solana.com homepage and
-    # locale-variant marketing pages (Russian/CN/etc.). Restrict to the
-    # /docs/ and /developers/ trees only.
     url_include: [/docs/, /developers/]
 
   - id: anchor-docs

--- a/ingestion/sources.yaml
+++ b/ingestion/sources.yaml
@@ -54,7 +54,7 @@ sources:
     primary_url: https://solana.com/docs
     start_urls:
       - https://solana.com/docs
-    url_include: [/docs/, /developers/]
+    url_include: [/docs, /developers]
 
   - id: anchor-docs
     name: Solana > Anchor Docs

--- a/ingestion/sources.yaml
+++ b/ingestion/sources.yaml
@@ -54,6 +54,10 @@ sources:
     primary_url: https://solana.com/docs
     start_urls:
       - https://solana.com/docs
+    # Without this, the BFS crawl picks up the solana.com homepage and
+    # locale-variant marketing pages (Russian/CN/etc.). Restrict to the
+    # /docs/ and /developers/ trees only.
+    url_include: [/docs/, /developers/]
 
   - id: anchor-docs
     name: Solana > Anchor Docs


### PR DESCRIPTION
## Summary

Smoke flag **C1** from 2026-04-29 testing: `get_documentation("anchor-docs")`'s tier-2 fallback led with Russian-localized solana.com marketing copy ("USDPT Стейблкоин запускается в 2026 году…") instead of docs content. Same noise leaks into every narrow RAG query that touches the `solana-docs` source.

## Root cause

The BFS crawl seeded at `https://solana.com/docs` follows external links back up to the marketing root, picking up locale variants and product/landing pages. The schema already has the right escape hatch — `url_include` is applied as a case-insensitive substring filter after URL collection (see `ingestion/crawl_and_index.py:303-319`). It just wasn't configured on this source.

## Fix

Add `url_include: [/docs/, /developers/]` to the `solana-docs` entry in [`ingestion/sources.yaml`](ingestion/sources.yaml). Keeps `/docs/` and `/developers/` (where the dev guides live), drops everything else. No code change required — the ingestion notebook picks up the new filter on its next run.

## Stale `coral-xyz/anchor` rows (smoke flag C2)

Out of scope for this PR but flagged for follow-up. The Delta table merge in `crawl_and_index.py:537-552` is upsert-by-id with no delete clause, so old `coral-xyz/anchor/blob/HEAD/…` rows will survive any re-ingestion. They need a one-shot SQL:

```sql
DELETE FROM <docs_table> WHERE url LIKE 'https://github.com/coral-xyz/anchor/%'
```

I'll run that operationally after this PR merges + the next ingestion job completes.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('ingestion/sources.yaml'))"` parses cleanly
- [x] `pnpm lint` clean (no TS touched)
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 15 files / 100 tests pass
- [ ] After ingestion job runs: `mcp__http-server__get_documentation("anchor-docs")` no longer leads with Russian/marketing copy
- [ ] After ingestion job runs: `mcp__http-server__Solana_Documentation_Search("how to derive a PDA in Anchor")` no longer surfaces solana.com homepage chunks