### PR TITLE
chore: drop Databricks App deploy — Vercel is the prod runtime

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,5 @@
 set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
 
-app := "solana-mcp"
 prod_yml := "prod.yml"
 
 fmt:
@@ -10,21 +9,15 @@ fmt:
 test:
     pnpm test
 
-# Deploy app + ingestion job via Databricks Asset Bundle. Reads gitignored
-# `prod.yml` for variable values (schema, warehouse_id, vs_index, ...).
+# Deploy ingestion job + dashboard via Databricks Asset Bundle. Reads
+# gitignored `prod.yml` for variable values (schema, warehouse_id, vs_index,
+# ...). The MCP server itself runs on Vercel and is deployed automatically
+# on push to main; the Databricks side only owns retrieval + analytics.
 deploy:
     @if [ ! -f "{{prod_yml}}" ]; then echo "missing {{prod_yml}} at repo root — see databricks.yml for required variables"; exit 1; fi
     @if [ ! -f "dashboards/solana_mcp.lvdash.json" ]; then echo "missing dashboards/solana_mcp.lvdash.json — cp dashboards/solana_mcp.example.lvdash.json dashboards/solana_mcp.lvdash.json and set catalog/schema per dataset"; exit 1; fi
-    pnpm build
-    # Enhanced pipeline: runs bundle deploy (job + app + dashboard resources)
-    # then creates a new app deployment with the bundle's config.env applied.
-    # Dashboard file has catalog/schema per dataset (gitignored real values).
-    DATABRICKS_BUNDLE_ENGINE=direct databricks apps deploy --target prod
+    databricks bundle deploy --target prod
 
 # Validate bundle config without deploying.
 bundle-validate:
     databricks bundle validate --target prod
-
-# Tail recent app logs.
-logs-app:
-    databricks apps logs {{app}} --tail-lines 100

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ just deploy   # builds, pushes ingestion job + dashboard
 
 ## Evals
 
-Local-only A/B harness lives in [`eval/`](eval/) (gitignored). See `eval/run.ts` and `eval/questions.jsonl`. Defaults to probing `mcp.solana.com/mcp`; configure both endpoints via `eval/.env`.
+Per-environment values (catalog, warehouse, index) live in the gitignored `prod.yml`; supply each variable listed under `variables:` in [`databricks.yml`](databricks.yml).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The official Solana Developer MCP. Purpose: serve up-to-date documentation acros
 
 - **Ingestion** ([`ingestion/`](ingestion/)): Databricks notebook crawls the sources listed in [`ingestion/sources.yaml`](ingestion/sources.yaml), chunks markdown, and writes embeddings into a Delta-backed Vector Search index.
 - **Retrieval** ([`lib/services/databricks/`](lib/services/databricks/)): MCP tools query the index via Databricks Vector Search; an optional cross-encoder Model Serving endpoint reranks results. `get_documentation` falls back to a SQL read of the `docs_chunks` Delta table when a source has no published `llms.txt`.
-- **Server** ([`lib/index.ts`](lib/index.ts), [`api/start.ts`](api/start.ts)): Exposes four tools over MCP — `Solana_Expert__Ask_For_Help` and `Solana_Documentation_Search` (semantic RAG), plus `list_sections` and `get_documentation` (canonical-spec retrieval modelled after the Svelte AI server). Deployed as a Databricks App.
+- **Server** ([`lib/index.ts`](lib/index.ts), [`api/server.ts`](api/server.ts)): Exposes four tools over MCP — `Solana_Expert__Ask_For_Help` and `Solana_Documentation_Search` (semantic RAG), plus `list_sections` and `get_documentation` (canonical-spec retrieval modelled after the Svelte AI server). Deployed on Vercel as a serverless function fronting `mcp.solana.com`; calls the Databricks workspace REST API directly for retrieval and analytics.
 - **Section catalogue** ([`ingestion/sources.yaml`](ingestion/sources.yaml) → [`lib/sources.generated.ts`](lib/sources.generated.ts)): `pnpm gen:sources` emits a typed catalogue of every source, its tags from a closed 21-section taxonomy, and `use_cases` keywords used by `list_sections` to route the agent.
 - **Analytics** ([`lib/services/databricks/analytics.ts`](lib/services/databricks/analytics.ts)): Tool calls + initializations land in the Databricks SQL warehouse for dashboards.
 
@@ -23,12 +23,19 @@ pnpm inspector  # connects MCP Inspector at http://127.0.0.1:6274
 
 ## Deploy
 
-Production runs as a Databricks App. The bundle config is in [`databricks.yml`](databricks.yml); per-environment values (catalog, warehouse, index) live in the gitignored `prod.yml` (see template inline in `databricks.yml`).
+Production runs on Vercel (mcp.solana.com → `api/server.ts`). Push to `main` triggers the Vercel deploy automatically; required env vars live in the Vercel project settings (`DATABRICKS_HOST`, `DATABRICKS_TOKEN`, `DATABRICKS_VS_INDEX`, `DATABRICKS_WAREHOUSE_ID`, `DATABRICKS_ANALYTICS_SCHEMA`, `DATABRICKS_RERANKER_ENDPOINT`).
+
+The Databricks side ([`databricks.yml`](databricks.yml)) deploys two resources via `just deploy`:
+
+- the daily ingestion job (`crawl_and_index.py` notebook) — crawls sources, MERGEs into Delta, syncs the Vector Search index;
+- the analytics dashboard (Lakeview).
+
+Per-environment values (catalog, warehouse, index) live in the gitignored `prod.yml` (see template inline in `databricks.yml`).
 
 ```bash
-just deploy   # builds, pushes the bundle, and deploys the app to prod
+just deploy   # builds, pushes ingestion job + dashboard
 ```
 
 ## Evals
 
-A/B harness comparing the deployed Databricks MCP against the legacy hosted MCP lives in [`eval/`](eval/). See [`eval/run.ts`](eval/run.ts) and [`eval/questions.jsonl`](eval/questions.jsonl).
+Local-only A/B harness lives in [`eval/`](eval/) (gitignored). See `eval/run.ts` and `eval/questions.jsonl`. Defaults to probing `mcp.solana.com/mcp`; configure both endpoints via `eval/.env`.

--- a/databricks.yml
+++ b/databricks.yml
@@ -20,9 +20,6 @@ variables:
     description: Vector Search endpoint name.
   vs_index:
     description: Fully-qualified Vector Search index.
-  reranker_endpoint:
-    description: Databricks Model Serving endpoint name used as a cross-encoder reranker.
-    default: databricks-claude-haiku-4-5
   notebook_sources_path:
     description: Workspace path to ingestion/sources.yaml once uploaded.
   bundle_root:
@@ -39,28 +36,6 @@ targets:
       root_path: ${var.bundle_root}
 
 resources:
-  apps:
-    solana_mcp:
-      name: solana-mcp
-      description: "Solana MCP server — Databricks-hosted TS MCP handler."
-      source_code_path: ${workspace.file_path}
-      compute_size: SMALL
-      config:
-        command:
-          - node
-          - dist/start.js
-        env:
-          - name: USE_DATABRICKS
-            value: "1"
-          - name: DATABRICKS_VS_INDEX
-            value: ${var.vs_index}
-          - name: DATABRICKS_WAREHOUSE_ID
-            value: ${var.warehouse_id}
-          - name: DATABRICKS_ANALYTICS_SCHEMA
-            value: ${var.catalog}.${var.schema}
-          - name: DATABRICKS_RERANKER_ENDPOINT
-            value: ${var.reranker_endpoint}
-
   jobs:
     solana_mcp_ingest:
       name: solana-mcp-ingest


### PR DESCRIPTION
## Summary

The Databricks App (`apps.solana_mcp`) is a redundant parallel deploy of the same MCP code that already runs on Vercel at `mcp.solana.com`. It receives zero real traffic and is costing ~**$270/mo** on the MEDIUM compute floor (Databricks deprecated the SMALL tier; the deploy fell back to MEDIUM despite our YAML asking for SMALL).

## Verified before removing

- DNS: `mcp.solana.com` CNAMEs to `cname.vercel-dns.com`; responses carry `server: Vercel` + `x-vercel-id: yul1::iad1::...`.
- Routing: [`vercel.json`](vercel.json) rewrites `/(.+)` → `/api/server`. [`api/server.ts`](api/server.ts) calls `createMcp()` from `lib/` and `dbxFetch()` directly against the Databricks workspace REST API. The App was never in the data path.
- Logs: `databricks apps logs solana-mcp` since boot today shows only `[start] solana-mcp listening on :8000` — zero real HTTP requests.
- Consumers: only `eval/.env` (gitignored) referenced the App URL. Used by the local A/B harness to compare Vercel vs App; both ran the same code path so the comparison was meaningless after the Inkeep retrieval backend was retired in #69.
- Env parity: `vercel env ls production` confirms every Databricks runtime var is set on Vercel — `DATABRICKS_HOST`, `_TOKEN`, `_VS_INDEX`, `_WAREHOUSE_ID`, `_ANALYTICS_SCHEMA`, `_RERANKER_ENDPOINT`. Reranking continues working exactly as before.

## Changes

- [`databricks.yml`](databricks.yml): drop the `apps:` block and the `reranker_endpoint` variable that only fed the App's env injection. The bundle now owns just retrieval + analytics resources (daily ingestion job + Lakeview dashboard).
- [`Justfile`](Justfile): `just deploy` now runs `databricks bundle deploy --target prod` (was `databricks apps deploy`). Drop the unused `logs-app` recipe and the `app` variable.
- [`README.md`](README.md): rewrite Server / Deploy / Evals sections to describe the Vercel runtime and the Databricks-side data plane.

## Operational follow-ups (not in this PR)

- After merge: `databricks apps stop solana-mcp` (reversible) or `databricks apps delete solana-mcp` (final). Stops the meter.
- Local `eval/.env` users repoint `DATABRICKS_MCP_URL` to `https://mcp.solana.com/mcp` or drop the URL and treat the harness as single-target. `eval/` is gitignored so no commit needed.

## What remains untouched

- [`api/start.ts`](api/start.ts) — orphan after this lands but kept for now (still useful for `pnpm start:app` local debugging). Can clean up in a follow-up.
- The warmup + graceful shutdown work from #75 is App-specific and now mostly dead code; will revisit in the same follow-up.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 15 files / 100 tests pass
- [x] `python -c "yaml.safe_load(open('databricks.yml'))"` parses cleanly; `apps` key gone, `jobs` + `dashboards` intact
- [ ] After merge: `just bundle-validate` succeeds without `apps:` references
- [ ] After merge: `databricks apps stop solana-mcp` confirms the App is no longer needed; `mcp.solana.com` continues serving from Vercel