### PR TITLE
fix(server): re-add initialize + tools/call analytics logging

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -1,11 +1,31 @@
 import * as dotenv from "dotenv";
 
 import { createMcp } from "../lib";
+import { logAnalytics } from "../lib/analytics";
 
 dotenv.config();
 
-function handler(req: Request) {
-  return createMcp()(req);
+const mcpHandler = createMcp();
+
+async function handler(req: Request): Promise<Response> {
+  if (req.method === "POST") {
+    void logIncomingRequest(req.clone());
+  }
+  return mcpHandler(req);
+}
+
+async function logIncomingRequest(req: Request): Promise<void> {
+  try {
+    const body = await req.text();
+    if (!body) return;
+    await logAnalytics({
+      event_type: "message_received",
+      session_id: req.headers.get("mcp-session-id") ?? undefined,
+      details: { body },
+    });
+  } catch (err) {
+    console.warn("[server] message_received logging failed:", err);
+  }
 }
 
 export { handler as GET };

--- a/tests/unit/api.server.test.ts
+++ b/tests/unit/api.server.test.ts
@@ -1,16 +1,21 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createMcpMock, requestHandlerMock, dotenvConfigMock } = vi.hoisted(() => {
+const { createMcpMock, requestHandlerMock, dotenvConfigMock, logAnalyticsMock } = vi.hoisted(() => {
   const requestHandlerMock = vi.fn();
   return {
     createMcpMock: vi.fn(() => requestHandlerMock),
     requestHandlerMock,
     dotenvConfigMock: vi.fn(),
+    logAnalyticsMock: vi.fn(),
   };
 });
 
 vi.mock("../../lib", () => ({
   createMcp: createMcpMock,
+}));
+
+vi.mock("../../lib/analytics", () => ({
+  logAnalytics: logAnalyticsMock,
 }));
 
 vi.mock("dotenv", () => ({
@@ -21,12 +26,21 @@ import { DELETE, GET, POST } from "../../api/server";
 
 describe("api server handler", () => {
   beforeEach(() => {
-    createMcpMock.mockClear();
     requestHandlerMock.mockReset();
     requestHandlerMock.mockResolvedValue(new Response("ok"));
+    logAnalyticsMock.mockReset();
+    logAnalyticsMock.mockResolvedValue(undefined);
   });
 
-  it("delegates GET, POST, and DELETE requests to createMcp handler", async () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("instantiates the MCP handler exactly once at module load", () => {
+    expect(createMcpMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("delegates GET, POST, and DELETE requests to the same handler", async () => {
     const getReq = new Request("http://localhost/mcp", { method: "GET" });
     const postReq = new Request("http://localhost/mcp", { method: "POST", body: "{}" });
     const deleteReq = new Request("http://localhost/mcp", { method: "DELETE" });
@@ -35,9 +49,49 @@ describe("api server handler", () => {
     await POST(postReq);
     await DELETE(deleteReq);
 
-    expect(createMcpMock).toHaveBeenCalledTimes(3);
     expect(requestHandlerMock).toHaveBeenNthCalledWith(1, getReq);
     expect(requestHandlerMock).toHaveBeenNthCalledWith(2, postReq);
     expect(requestHandlerMock).toHaveBeenNthCalledWith(3, deleteReq);
+  });
+
+  it("emits a `message_received` analytics event for POST requests with a body", async () => {
+    const body = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+    const req = new Request("http://localhost/mcp", {
+      method: "POST",
+      body,
+      headers: { "mcp-session-id": "sess-1" },
+    });
+
+    await POST(req);
+    // logIncomingRequest is fire-and-forget — flush microtasks
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(logAnalyticsMock).toHaveBeenCalledTimes(1);
+    expect(logAnalyticsMock).toHaveBeenCalledWith({
+      event_type: "message_received",
+      session_id: "sess-1",
+      details: { body },
+    });
+  });
+
+  it("does not emit analytics for GET or DELETE requests", async () => {
+    await GET(new Request("http://localhost/mcp", { method: "GET" }));
+    await DELETE(new Request("http://localhost/mcp", { method: "DELETE" }));
+    await new Promise(resolve => setImmediate(resolve));
+    expect(logAnalyticsMock).not.toHaveBeenCalled();
+  });
+
+  it("skips analytics for POST requests with an empty body", async () => {
+    const req = new Request("http://localhost/mcp", { method: "POST", body: "" });
+    await POST(req);
+    await new Promise(resolve => setImmediate(resolve));
+    expect(logAnalyticsMock).not.toHaveBeenCalled();
+  });
+
+  it("does not block the response when logAnalytics throws", async () => {
+    logAnalyticsMock.mockRejectedValueOnce(new Error("warehouse unavailable"));
+    const req = new Request("http://localhost/mcp", { method: "POST", body: "{}" });
+    const res = await POST(req);
+    expect(res).toBeInstanceOf(Response);
   });
 });


### PR DESCRIPTION
## Summary

The dashboard `Clients` widget has been frozen since 2026-04-22 — last write to `mcp_initializations`. Root cause: the Vercel handler was bare:

```ts
function handler(req: Request) {
  return createMcp()(req);
}
```

`logAnalytics({ event_type: "message_received", details: { body } })` is the call that triggers `logInitialization()` ([lib/analytics.ts:28-50](lib/analytics.ts#L28)). Nothing was emitting it, so `mcp_initializations` rows stopped (and the request-side of `mcp_tool_calls` was never written either — only response-side from `generalSolanaTools.ts`).

## Fix

- Wrap the handler in `api/server.ts` to clone the incoming request, read the body, and fire `logAnalytics({ event_type: "message_received", details: { body } })` in the background. `logAnalytics` parses the JSON-RPC envelope and routes `initialize` → `mcp_initializations`, `tools/call` → `mcp_tool_calls.request`. The session id from `Mcp-Session-Id` header is forwarded.
- Fire-and-forget (`void` + try/catch). A warehouse outage cannot block the user-facing response.

## Bonus perf fix

While in there: hoist `const mcpHandler = createMcp()` to module load. The previous code rebuilt the entire tool registry per request. Single instance per warm Vercel function container now.

## Tests

[`tests/unit/api.server.test.ts`](tests/unit/api.server.test.ts) — 5 new cases:

- Module-level `createMcp` called exactly once
- POST with body emits the expected `message_received` event with the raw body + session id
- GET / DELETE / empty-body POST emit nothing
- A throwing `logAnalytics` does not break the response

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 14 files / 103 tests pass (+5 from new server tests)
- [ ] After deploy: `mcp_initializations` starts receiving fresh rows on next handshake; dashboard `Clients` widget unfreezes
- [ ] After deploy: `mcp_tool_calls` request-side rows resume too (currently only `row_type='response'` populated)