### PR TITLE
ci: add Cloud Run deploy workflow + Doppler secret loader

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -56,9 +56,6 @@ jobs:
           echo "Submitted $BUILD_ID"
           echo "Logs: https://console.cloud.google.com/cloud-build/builds/$BUILD_ID?project=$PROJECT"
 
-          # Poll for up to 40 min — matches kora's deploy workflow. The job
-          # has no explicit timeout-minutes, so it falls back to GHA's 360 min
-          # default; the 40 min poll fits inside that easily.
           STATUS=
           for i in $(seq 1 80); do
             STATUS=$(gcloud builds describe "$BUILD_ID" --project="$PROJECT" --format='value(status)')

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-    inputs:
-      ref:
-        description: "Git ref to deploy"
-        required: false
-        default: main
 
 permissions:
   contents: read
@@ -17,18 +12,16 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     concurrency:
       group: cloud-run-deploy-prod
       cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ inputs.ref || github.sha }}
 
       - name: Load deploy config from Doppler
-        uses: dopplerhq/secrets-fetch-action@v2.0.0
+        uses: dopplerhq/secrets-fetch-action@451892f16195f9ac360e1a5bcbf0b5fd0e957534 # v2.0.0
         with:
           auth-method: oidc
           doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
@@ -37,12 +30,12 @@ jobs:
           inject-env-vars: true
 
       - id: auth
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
           service_account: ${{ env.GCP_DEPLOYER_SERVICE_ACCOUNT }}
 
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
       - id: build
         env:
@@ -64,10 +57,12 @@ jobs:
           echo "Submitted $BUILD_ID"
           echo "Logs: https://console.cloud.google.com/cloud-build/builds/$BUILD_ID?project=$PROJECT"
 
+          # Poll for up to ~20 min — kept under the 30 min job timeout so the
+          # GH runner does not get killed mid-poll, leaving an orphan build.
           STATUS=
-          for i in $(seq 1 80); do
+          for i in $(seq 1 40); do
             STATUS=$(gcloud builds describe "$BUILD_ID" --project="$PROJECT" --format='value(status)')
-            echo "  $i/80: $STATUS"
+            echo "  $i/40: $STATUS"
             case "$STATUS" in
               SUCCESS) break ;;
               FAILURE|TIMEOUT|CANCELLED|EXPIRED|INTERNAL_ERROR) exit 1 ;;
@@ -79,7 +74,7 @@ jobs:
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
 
       - id: deploy
-        uses: google-github-actions/deploy-cloudrun@v3
+        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d # v3.0.1
         with:
           service: ${{ env.CLOUD_RUN_SERVICE }}
           region: ${{ env.GCP_REGION }}

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -12,7 +12,6 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     concurrency:
       group: cloud-run-deploy-prod
       cancel-in-progress: false
@@ -57,12 +56,13 @@ jobs:
           echo "Submitted $BUILD_ID"
           echo "Logs: https://console.cloud.google.com/cloud-build/builds/$BUILD_ID?project=$PROJECT"
 
-          # Poll for up to ~20 min — kept under the 30 min job timeout so the
-          # GH runner does not get killed mid-poll, leaving an orphan build.
+          # Poll for up to 40 min — matches kora's deploy workflow. The job
+          # has no explicit timeout-minutes, so it falls back to GHA's 360 min
+          # default; the 40 min poll fits inside that easily.
           STATUS=
-          for i in $(seq 1 40); do
+          for i in $(seq 1 80); do
             STATUS=$(gcloud builds describe "$BUILD_ID" --project="$PROJECT" --format='value(status)')
-            echo "  $i/40: $STATUS"
+            echo "  $i/80: $STATUS"
             case "$STATUS" in
               SUCCESS) break ;;
               FAILURE|TIMEOUT|CANCELLED|EXPIRED|INTERNAL_ERROR) exit 1 ;;

--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -1,0 +1,111 @@
+name: Deploy Cloud Run
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to deploy"
+        required: false
+        default: main
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    concurrency:
+      group: cloud-run-deploy-prod
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Load deploy config from Doppler
+        uses: dopplerhq/secrets-fetch-action@v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'solana-developer-mcp' }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'prd_github' }}
+          inject-env-vars: true
+
+      - id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
+          service_account: ${{ env.GCP_DEPLOYER_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - id: build
+        env:
+          REGION: ${{ env.GCP_REGION }}
+          PROJECT: ${{ env.GCP_PROJECT_ID }}
+          SERVICE: ${{ env.CLOUD_RUN_SERVICE }}
+        run: |
+          set -euo pipefail
+          IMAGE="${REGION}-docker.pkg.dev/${PROJECT}/${SERVICE}/${SERVICE}:${GITHUB_SHA::12}"
+
+          # --async + poll: log streaming requires Project Viewer/Owner;
+          # the scoped deployer SA does not have it.
+          BUILD_ID=$(gcloud builds submit . \
+            --tag "$IMAGE" \
+            --project="$PROJECT" \
+            --gcs-source-staging-dir="gs://${PROJECT}_cloudbuild/source" \
+            --async --format='value(id)')
+          [ -n "$BUILD_ID" ] || { echo "empty build id"; exit 1; }
+          echo "Submitted $BUILD_ID"
+          echo "Logs: https://console.cloud.google.com/cloud-build/builds/$BUILD_ID?project=$PROJECT"
+
+          STATUS=
+          for i in $(seq 1 80); do
+            STATUS=$(gcloud builds describe "$BUILD_ID" --project="$PROJECT" --format='value(status)')
+            echo "  $i/80: $STATUS"
+            case "$STATUS" in
+              SUCCESS) break ;;
+              FAILURE|TIMEOUT|CANCELLED|EXPIRED|INTERNAL_ERROR) exit 1 ;;
+            esac
+            sleep 30
+          done
+          [ "$STATUS" = "SUCCESS" ] || { echo "timed out polling $BUILD_ID"; exit 1; }
+
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+      - id: deploy
+        uses: google-github-actions/deploy-cloudrun@v3
+        with:
+          service: ${{ env.CLOUD_RUN_SERVICE }}
+          region: ${{ env.GCP_REGION }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          image: ${{ steps.build.outputs.image }}
+          service_account: ${{ env.GCP_RUNTIME_SERVICE_ACCOUNT }}
+          env_vars: |-
+            DATABRICKS_HOST=${{ env.DATABRICKS_HOST }}
+            DATABRICKS_TOKEN=${{ env.DATABRICKS_TOKEN }}
+            DATABRICKS_VS_INDEX=${{ env.DATABRICKS_VS_INDEX }}
+            DATABRICKS_WAREHOUSE_ID=${{ env.DATABRICKS_WAREHOUSE_ID }}
+            DATABRICKS_ANALYTICS_SCHEMA=${{ env.DATABRICKS_ANALYTICS_SCHEMA }}
+            DATABRICKS_RERANKER_ENDPOINT=${{ env.DATABRICKS_RERANKER_ENDPOINT }}
+            REDIS_URL=${{ env.REDIS_URL }}
+          env_vars_update_strategy: overwrite
+          flags: >-
+            --allow-unauthenticated
+            --port=8080
+            --cpu=1
+            --memory=512Mi
+            --concurrency=80
+            --min-instances=0
+            --max-instances=10
+            --timeout=900s
+            --vpc-connector=${{ env.VPC_CONNECTOR }}
+            --vpc-egress=private-ranges-only
+
+      - name: Print service URL
+        run: echo "Deployed ${{ env.CLOUD_RUN_SERVICE }} -> ${{ steps.deploy.outputs.url }}"

--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,0 +1,3 @@
+setup:
+  - project: solana-developer-mcp
+    config: dev_personal


### PR DESCRIPTION
## Summary

Phase 4 of the Vercel → GCP migration. Adds a GitHub Actions workflow that deploys the Cloud Run container introduced in #80 on every push to `main` (and on demand). Matches the Kora project pattern at `~/git-solana/kora/.github/workflows/deploy-devnet-paymaster.yml`.

## Workflow

1. **Doppler** — `dopplerhq/secrets-fetch-action@v2.0.0` w/ OIDC pulls config from `solana-developer-mcp` / `prd_github` and injects every secret as a workflow env var. The Doppler Service Identity is scoped to `repo:solana-foundation/solana-mcp-official:ref:refs/heads/main`, so PRs cannot fetch prod secrets.
2. **GCP auth** — `google-github-actions/auth@v3` exchanges GitHub OIDC for impersonation of `solana-mcp-deployer@devnet-tools.iam.gserviceaccount.com` via the Workload Identity Federation pool Jacob set up.
3. **Image build** — `gcloud builds submit` runs Cloud Build and tags the image in Artifact Registry. `--async` + poll, so the deployer SA does not need project-level log read.
4. **Deploy** — `google-github-actions/deploy-cloudrun@v3` rolls out to Cloud Run with the runtime SA (`solana-mcp-runtime`), the shared VPC connector (`devnet-vpc-connector`), `--vpc-egress=private-ranges-only`, and the 7 runtime env vars sourced from Doppler.

## Files

- [`.github/workflows/deploy-cloudrun.yml`](.github/workflows/deploy-cloudrun.yml) — the workflow.
- [`doppler.yaml`](doppler.yaml) — local-dev pointer so `doppler run -- pnpm dev:local` works.
- [`docs/gcp-migration-bootstrap.md`](docs/gcp-migration-bootstrap.md) — Jacob's IAM bootstrap (one-time, 9 cmds) + Doppler secret list + GitHub Variables list + DNS cutover steps.

## Net new GCP IAM grant for Jacob (one cmd)

```bash
gcloud projects add-iam-policy-binding devnet-tools \
  --member="serviceAccount:solana-mcp-deployer@devnet-tools.iam.gserviceaccount.com" \
  --role="roles/cloudbuild.builds.editor" --condition=None
gcloud services enable cloudbuild.googleapis.com --project=devnet-tools
```

Cloud Build runs the image build (matches Kora). Without this grant the workflow's `gcloud builds submit` step fails.

## Followup (out of scope)

The 7 secrets currently in GCP Secret Manager (created earlier in this session pre-Doppler-decision) become orphan once Doppler is the source of truth. They get deleted after the first successful Doppler-driven deploy.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` 14 / 103
- [x] workflow YAML lints clean (no GHA error annotations)
- [ ] After merge: workflow runs on push to main, deploys to Cloud Run, prints `*.run.app` URL
- [ ] Smoke `/healthz` + 4 MCP tools at the Cloud Run URL before any DNS cutover