### PR TITLE
fix(deploy): apply runtime SA via flags + rename health route

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -77,7 +77,6 @@ jobs:
           region: ${{ env.GCP_REGION }}
           project_id: ${{ env.GCP_PROJECT_ID }}
           image: ${{ steps.build.outputs.image }}
-          service_account: ${{ env.GCP_RUNTIME_SERVICE_ACCOUNT }}
           env_vars: |-
             DATABRICKS_HOST=${{ env.DATABRICKS_HOST }}
             DATABRICKS_TOKEN=${{ env.DATABRICKS_TOKEN }}
@@ -88,6 +87,7 @@ jobs:
             REDIS_URL=${{ env.REDIS_URL }}
           env_vars_update_strategy: overwrite
           flags: >-
+            --service-account=${{ env.GCP_RUNTIME_SERVICE_ACCOUNT }}
             --allow-unauthenticated
             --port=8080
             --cpu=1

--- a/server/cloudrun.ts
+++ b/server/cloudrun.ts
@@ -18,7 +18,7 @@ const server = createServer((req, res) => {
 });
 
 async function route(req: IncomingMessage, res: ServerResponse): Promise<void> {
-  if (req.method === "GET" && req.url === "/healthz") {
+  if (req.method === "GET" && req.url === "/health") {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ ok: true }));
     return;


### PR DESCRIPTION
## Summary
- Move `--service-account=${GCP_RUNTIME_SERVICE_ACCOUNT}` into the `flags:` block of `deploy-cloudrun@v3`. The action surfaces no `service_account` input, so the previous field was ignored and the first deploy booted Cloud Run under the compute default SA instead of the scoped `solana-mcp-runtime`. Action's own warning made this visible: `Unexpected input(s) 'service_account', valid inputs are [...]`.
- Rename `/healthz` -> `/health` in `server/cloudrun.ts`. Cloud Run's GFE reserves `/healthz` and returns its own HTML 404 before the request reaches the container (verified: no `x-cloud-trace-context` header, no log line). `/health` routes to the app normally.

## Test plan
- [ ] CI green (lint / typecheck / test)
- [ ] Merge -> deploy workflow runs to completion
- [ ] `gcloud run services describe solana-mcp ...` shows `serviceAccountName: solana-mcp-runtime@devnet-tools.iam.gserviceaccount.com`
- [ ] `curl https://<run-url>/health` returns `{"ok":true}` with `x-cloud-trace-context` header present