### PR TITLE
feat(rust-autofixer): Anchor tier-3 cross-handler visitors

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,6 @@
 .corepack/
+.claude/
+.codex/
 .docs/
 .pnpm-store/
 build/

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,7 +13,7 @@ Tools:
 2. get_documentation(section: string | string[]) — fetch full canonical docs. \`section\` accepts a source id (e.g. "anchor-docs") OR a section taxonomy id (e.g. "frameworks") which expands to every source tagged with that section. Pass an array to fetch several at once. Token-intensive (per-source cap 50 KB, total cap 200 KB).
 3. Solana_Documentation_Search(query) — semantic RAG search. Use for narrow questions where you don't need full source specs — e.g. "how do I derive a PDA with Anchor?". Returns relevant chunks.
 4. Solana_Expert__Ask_For_Help(question) — same backend as Solana_Documentation_Search, framed for how-to / debugging questions. Provide errors, snippets, intent.
-5. rust_autofixer(code, filename?, framework?) — static-analyses Solana program Rust (Pinocchio full coverage; Anchor tier-1 attribute-only) and returns \`{ issues, suggestions, require_another_tool_call_after_fixing }\`. MUST be called whenever you write or modify Solana program code, BEFORE returning code to the user. After applying fixes, call again; loop until \`require_another_tool_call_after_fixing\` is false.
+5. rust_autofixer(code, filename?, framework?) — static-analyses Solana program Rust (Pinocchio + Anchor) and returns \`{ issues, suggestions, require_another_tool_call_after_fixing }\`. MUST be called whenever you write or modify Solana program code, BEFORE returning code to the user. After applying fixes, call again; loop until \`require_another_tool_call_after_fixing\` is false.
 
 Routing:
 - Canonical spec for a library / program / framework → list_sections, then get_documentation.

--- a/lib/tools/rustAutofixer/index.ts
+++ b/lib/tools/rustAutofixer/index.ts
@@ -40,9 +40,7 @@ export function createRustAutofixerTool(): SolanaTool {
       framework: z
         .enum(["pinocchio", "anchor", "auto"])
         .optional()
-        .describe(
-          "Framework hint. Default 'auto' — detect from imports / attributes. Anchor coverage currently spans the tier-1 attribute-only checks; handler-body checks land in a follow-up.",
-        ),
+        .describe("Framework hint. Default 'auto' — detect from imports / attributes."),
     },
     outputSchema: {
       issues: z.array(issueSchema),

--- a/lib/tools/rustAutofixer/index.ts
+++ b/lib/tools/rustAutofixer/index.ts
@@ -25,7 +25,7 @@ MUST be called whenever the user asks to write or modify Solana program code, BE
 
 Pinocchio: missing signer/owner/discriminator checks, unverified program IDs, sysvar spoofing, arbitrary CPI, unvalidated PDA derivation, unchecked arithmetic, signers verified but unused, accounts with no \`verify_*\` call, type cosplay, unchecked deserialization, account closure, re-initialization, rent-exempt, authority escalation, Token-2022 extensions, instruction data bounds, PDA seed collision, bump canonicalization, writable mutation, account relationship, account borrow safety, unsafe unwrap/expect, events emitted via \`msg!\`.
 
-Anchor (tier 1 + tier 2): \`seeds\` without \`bump\`, \`init\` without \`space\` / \`payer\`, \`realloc\` missing \`realloc::payer\` / \`realloc::zero\`, \`UncheckedAccount\` / \`AccountInfo\` opt-outs, \`Account<Mint>\` / \`Account<TokenAccount>\` instead of \`InterfaceAccount\`, manual \`.is_signer\` checks, \`require_keys_eq!\` instead of \`has_one\`, and \`msg!\` events inside \`#[program]\` (use \`emit!\`). Anchor CPI-flow + cross-handler checks ship in tier 3.`;
+Anchor: \`seeds\` without \`bump\`, \`init\` without \`space\` / \`payer\`, \`realloc\` missing \`realloc::payer\` / \`realloc::zero\`, \`UncheckedAccount\` / \`AccountInfo\` opt-outs, \`Account<Mint>\` / \`Account<TokenAccount>\` instead of \`InterfaceAccount\`, manual \`.is_signer\` checks, \`require_keys_eq!\` instead of \`has_one\`, \`msg!\` events inside \`#[program]\` (use \`emit!\`), \`ctx.accounts.X\` mutation without \`mut\` constraint, \`CpiContext::new\` with untyped program account, and manual lamport drain without \`close = ...\`.`;
 
 export function createRustAutofixerTool(): SolanaTool {
   return {

--- a/lib/tools/rustAutofixer/visitors/_anchor-helpers.ts
+++ b/lib/tools/rustAutofixer/visitors/_anchor-helpers.ts
@@ -282,3 +282,71 @@ export function isInsideProgramModule(node: Node, programModule: Node | null): b
   if (!programModule) return false;
   return node.startIndex >= programModule.startIndex && node.endIndex <= programModule.endIndex;
 }
+
+/**
+ * For `ctx.accounts.<X>` style chains, walk inward and return the segment
+ * immediately after `ctx.accounts.`. Returns null if the chain doesn't match.
+ */
+export function ctxAccountsField(node: Node): string | null {
+  // Climb up through field_expression chains until we find the segment whose receiver is `ctx.accounts`.
+  let cursor: Node | null = node;
+  let lastField: string | null = null;
+  while (cursor) {
+    if (cursor.type !== "field_expression") return null;
+    const value = cursor.childForFieldName("value");
+    const field = cursor.childForFieldName("field");
+    if (!value || !field) return null;
+    if (value.type === "field_expression") {
+      const innerValue = value.childForFieldName("value");
+      const innerField = value.childForFieldName("field");
+      if (innerValue?.type === "identifier" && innerValue.text === "ctx" && innerField?.text === "accounts") {
+        return field.text;
+      }
+    }
+    // Step inward through the chain — the outer-most `ctx.accounts.X.Y` has Y as field, X.Y nested.
+    lastField = field.text;
+    cursor = value;
+    if (cursor.type !== "field_expression") break;
+  }
+  return lastField;
+}
+
+/** Find every `ctx.accounts.<X>` access inside a given scope and return the set of `X` values. */
+export function collectCtxAccountsAccesses(scope: Node): Set<string> {
+  const out = new Set<string>();
+  const cursor = scope.walk();
+  const visit = (): void => {
+    const n = cursor.currentNode();
+    if (n.type === "field_expression") {
+      const value = n.childForFieldName("value");
+      const field = n.childForFieldName("field");
+      if (value?.type === "field_expression" && field) {
+        const innerValue = value.childForFieldName("value");
+        const innerField = value.childForFieldName("field");
+        if (innerValue?.type === "identifier" && innerValue.text === "ctx" && innerField?.text === "accounts") {
+          out.add(field.text);
+        }
+      }
+    }
+    if (cursor.gotoFirstChild()) {
+      do {
+        visit();
+      } while (cursor.gotoNextSibling());
+      cursor.gotoParent();
+    }
+  };
+  visit();
+  cursor.delete();
+  return out;
+}
+
+/** Look up all fields named `fieldName` across every Accounts struct in the file. */
+export function findFieldsByName(structs: AnchorStruct[], fieldName: string): AnchorField[] {
+  const out: AnchorField[] = [];
+  for (const s of structs) {
+    for (const f of s.fields) {
+      if (f.name === fieldName) out.push(f);
+    }
+  }
+  return out;
+}

--- a/lib/tools/rustAutofixer/visitors/_anchor-helpers.ts
+++ b/lib/tools/rustAutofixer/visitors/_anchor-helpers.ts
@@ -218,53 +218,59 @@ function findFieldType(fieldNode: Node): Node | null {
   return null;
 }
 
-/**
- * Build the per-file anchor context: every `#[derive(Accounts)]` struct with
- * its fields and parsed attributes, plus a pointer to the `#[program]` module
- * (if any). Walks source_file's named children pairwise to associate
- * attribute_item with the immediately-following struct/mod.
- */
 export function collectAnchorContext(tree: Tree): AnchorContext {
   const structs: AnchorStruct[] = [];
   let programModule: Node | null = null;
-  const root = tree.rootNode;
 
-  let pendingIsAccountsDerive = false;
-  let pendingIsProgramAttr = false;
-  for (let i = 0; i < root.namedChildCount; i++) {
-    const node = root.namedChild(i);
-    if (!node) continue;
+  function scanItems(container: Node): void {
+    let pendingIsAccountsDerive = false;
+    let pendingIsProgramAttr = false;
+    for (let i = 0; i < container.namedChildCount; i++) {
+      const node = container.namedChild(i);
+      if (!node) continue;
 
-    if (node.type === "attribute_item") {
-      if (attributeIsDeriveAccounts(node)) pendingIsAccountsDerive = true;
-      else if (isProgramAttr(node)) pendingIsProgramAttr = true;
-      continue;
-    }
-
-    if (node.type === "struct_item") {
-      if (pendingIsAccountsDerive) {
-        const nameNode = node.childForFieldName("name");
-        const name = nameNode?.text ?? "<anonymous>";
-        structs.push({ name, structNode: node, fields: collectStructFields(node) });
+      if (node.type === "attribute_item") {
+        if (attributeIsDeriveAccounts(node)) pendingIsAccountsDerive = true;
+        else if (isProgramAttr(node)) pendingIsProgramAttr = true;
+        continue;
       }
+
+      if (node.type === "struct_item") {
+        if (pendingIsAccountsDerive) {
+          const nameNode = node.childForFieldName("name");
+          const name = nameNode?.text ?? "<anonymous>";
+          structs.push({ name, structNode: node, fields: collectStructFields(node) });
+        }
+        pendingIsAccountsDerive = false;
+        pendingIsProgramAttr = false;
+        continue;
+      }
+
+      if (node.type === "mod_item") {
+        if (pendingIsProgramAttr) programModule = node;
+        const body = findDeclarationList(node);
+        pendingIsAccountsDerive = false;
+        pendingIsProgramAttr = false;
+        if (body) scanItems(body);
+        continue;
+      }
+
       pendingIsAccountsDerive = false;
       pendingIsProgramAttr = false;
-      continue;
     }
-
-    if (node.type === "mod_item") {
-      if (pendingIsProgramAttr) programModule = node;
-      pendingIsAccountsDerive = false;
-      pendingIsProgramAttr = false;
-      continue;
-    }
-
-    // Any other top-level node clears the pending flags.
-    pendingIsAccountsDerive = false;
-    pendingIsProgramAttr = false;
   }
 
+  scanItems(tree.rootNode);
+
   return { structs, programModule };
+}
+
+function findDeclarationList(node: Node): Node | null {
+  for (let i = 0; i < node.namedChildCount; i++) {
+    const c = node.namedChild(i);
+    if (c?.type === "declaration_list") return c;
+  }
+  return null;
 }
 
 function isProgramAttr(attrItem: Node): boolean {
@@ -288,9 +294,7 @@ export function isInsideProgramModule(node: Node, programModule: Node | null): b
  * immediately after `ctx.accounts.`. Returns null if the chain doesn't match.
  */
 export function ctxAccountsField(node: Node): string | null {
-  // Climb up through field_expression chains until we find the segment whose receiver is `ctx.accounts`.
   let cursor: Node | null = node;
-  let lastField: string | null = null;
   while (cursor) {
     if (cursor.type !== "field_expression") return null;
     const value = cursor.childForFieldName("value");
@@ -303,12 +307,9 @@ export function ctxAccountsField(node: Node): string | null {
         return field.text;
       }
     }
-    // Step inward through the chain — the outer-most `ctx.accounts.X.Y` has Y as field, X.Y nested.
-    lastField = field.text;
     cursor = value;
-    if (cursor.type !== "field_expression") break;
   }
-  return lastField;
+  return null;
 }
 
 /** Find every `ctx.accounts.<X>` access inside a given scope and return the set of `X` values. */
@@ -349,4 +350,74 @@ export function findFieldsByName(structs: AnchorStruct[], fieldName: string): An
     }
   }
   return out;
+}
+
+export function findFieldsForHandlerContext(ctx: AnchorContext, node: Node, fieldName: string): AnchorField[] {
+  const structName = findEnclosingContextStructName(node);
+  const structs = structName ? ctx.structs.filter(s => s.name === structName) : ctx.structs;
+  return findFieldsByName(structs, fieldName);
+}
+
+function findEnclosingContextStructName(node: Node): string | null {
+  let cursor: Node | null = node;
+  while (cursor) {
+    if (cursor.type === "function_item") return contextStructNameFromFunction(cursor);
+    cursor = cursor.parent;
+  }
+  return null;
+}
+
+function contextStructNameFromFunction(functionNode: Node): string | null {
+  const parameters = functionNode.childForFieldName("parameters") ?? findParameters(functionNode);
+  if (!parameters) return null;
+  for (let i = 0; i < parameters.namedChildCount; i++) {
+    const param = parameters.namedChild(i);
+    if (!param || param.type !== "parameter") continue;
+    const typeNode = param.childForFieldName("type") ?? findParameterType(param);
+    const name = typeNode ? contextStructNameFromType(typeNode) : null;
+    if (name) return name;
+  }
+  return null;
+}
+
+function findParameters(functionNode: Node): Node | null {
+  for (let i = 0; i < functionNode.namedChildCount; i++) {
+    const c = functionNode.namedChild(i);
+    if (c?.type === "parameters") return c;
+  }
+  return null;
+}
+
+function findParameterType(parameterNode: Node): Node | null {
+  for (let i = 0; i < parameterNode.namedChildCount; i++) {
+    const c = parameterNode.namedChild(i);
+    if (!c) continue;
+    if (c.type === "generic_type" || c.type === "scoped_type_identifier" || c.type === "type_identifier") return c;
+  }
+  return null;
+}
+
+function contextStructNameFromType(typeNode: Node): string | null {
+  if (typeNode.type !== "generic_type") return null;
+  const head = typeNode.namedChild(0);
+  if (!head || typeTailIdentifier(head) !== "Context") return null;
+  const args = typeNode.childForFieldName("type_arguments") ?? typeNode.namedChild(1);
+  return args ? lastTypeIdentifier(args) : null;
+}
+
+function typeTailIdentifier(node: Node): string | null {
+  if (node.type === "type_identifier") return node.text;
+  if (node.type === "scoped_type_identifier" || node.type === "generic_type") {
+    const last = node.namedChild(node.namedChildCount - 1);
+    return last ? typeTailIdentifier(last) : null;
+  }
+  return null;
+}
+
+function lastTypeIdentifier(node: Node): string | null {
+  let result: string | null = null;
+  walk(node, n => {
+    if (n.type === "type_identifier") result = n.text;
+  });
+  return result;
 }

--- a/lib/tools/rustAutofixer/visitors/anchor-close-without-receiver.ts
+++ b/lib/tools/rustAutofixer/visitors/anchor-close-without-receiver.ts
@@ -1,0 +1,68 @@
+import type Parser from "web-tree-sitter";
+import type { Visitor } from "../types.js";
+import { formatLocation } from "../types.js";
+import { collectCtxAccountsAccesses, findFieldsByName, isInsideProgramModule } from "./_anchor-helpers.js";
+
+type Node = Parser.SyntaxNode;
+
+function isZeroLiteral(node: Node): boolean {
+  if (node.type === "integer_literal") return node.text === "0";
+  if (node.type === "parenthesized_expression") {
+    const inner = node.namedChild(0);
+    return inner ? isZeroLiteral(inner) : false;
+  }
+  return false;
+}
+
+function lhsTouchesLamports(left: Node): boolean {
+  let found = false;
+  const cursor = left.walk();
+  const visit = (): void => {
+    const n = cursor.currentNode();
+    if (found) return;
+    if (n.type === "field_identifier" && n.text === "lamports") found = true;
+    if (n.type === "identifier" && n.text === "lamports") found = true;
+    if (!found && cursor.gotoFirstChild()) {
+      do {
+        visit();
+      } while (cursor.gotoNextSibling());
+      cursor.gotoParent();
+    }
+  };
+  visit();
+  cursor.delete();
+  return found;
+}
+
+export const anchorCloseWithoutReceiver: Visitor = {
+  name: "anchor-close-without-receiver",
+  severity: "critical",
+  appliesTo: ["anchor"],
+  enter: {
+    assignment_expression(node, ctx) {
+      if (!isInsideProgramModule(node, ctx.anchor.programModule)) return;
+      const left = node.childForFieldName("left");
+      const right = node.childForFieldName("right");
+      if (!left || !right) return;
+      if (!isZeroLiteral(right)) return;
+      if (!lhsTouchesLamports(left)) return;
+      // Find ctx.accounts.X mentions inside the LHS chain (or its statement neighborhood) to identify the account.
+      const fields = collectCtxAccountsAccesses(left);
+      if (fields.size === 0) return;
+      for (const fieldName of fields) {
+        const candidates = findFieldsByName(ctx.anchor.structs, fieldName);
+        if (candidates.length === 0) continue;
+        const hasClose = candidates.some(f => f.attribute?.kvPairs.has("close"));
+        if (hasClose) continue;
+        ctx.output.issues.push({
+          severity: "critical",
+          rule: "anchor-close-without-receiver",
+          title: `Manual lamport drain on ${fieldName} without \`close = ...\` constraint`,
+          location: formatLocation(ctx.filename, node),
+          description: `\`ctx.accounts.${fieldName}\` is having its lamports set to 0 in a handler, but the Accounts struct doesn't declare \`#[account(close = <receiver>)]\` for this field. Without \`close\`, Anchor won't reassign the account to the system program and zero its data buffer — the account remains usable in the same transaction (reload attack).`,
+          suggestion: `Add \`close = <receiver>\` to the \`#[account(...)]\` attribute on \`${fieldName}\` (where \`<receiver>\` is the account that absorbs the lamports). Drop the manual lamport-drain code — Anchor handles closure correctly when the constraint is declared.`,
+        });
+      }
+    },
+  },
+};

--- a/lib/tools/rustAutofixer/visitors/anchor-close-without-receiver.ts
+++ b/lib/tools/rustAutofixer/visitors/anchor-close-without-receiver.ts
@@ -1,7 +1,7 @@
 import type Parser from "web-tree-sitter";
 import type { Visitor } from "../types.js";
 import { formatLocation } from "../types.js";
-import { collectCtxAccountsAccesses, findFieldsByName, isInsideProgramModule } from "./_anchor-helpers.js";
+import { collectCtxAccountsAccesses, findFieldsForHandlerContext, isInsideProgramModule } from "./_anchor-helpers.js";
 
 type Node = Parser.SyntaxNode;
 
@@ -50,7 +50,7 @@ export const anchorCloseWithoutReceiver: Visitor = {
       const fields = collectCtxAccountsAccesses(left);
       if (fields.size === 0) return;
       for (const fieldName of fields) {
-        const candidates = findFieldsByName(ctx.anchor.structs, fieldName);
+        const candidates = findFieldsForHandlerContext(ctx.anchor, node, fieldName);
         if (candidates.length === 0) continue;
         const hasClose = candidates.some(f => f.attribute?.kvPairs.has("close"));
         if (hasClose) continue;

--- a/lib/tools/rustAutofixer/visitors/anchor-cpi-context-unverified.ts
+++ b/lib/tools/rustAutofixer/visitors/anchor-cpi-context-unverified.ts
@@ -1,0 +1,98 @@
+import type Parser from "web-tree-sitter";
+import type { Visitor } from "../types.js";
+import { formatLocation } from "../types.js";
+import { ctxAccountsField, findFieldsByName, isInsideProgramModule } from "./_anchor-helpers.js";
+import { walk } from "../walk.js";
+
+type Node = Parser.SyntaxNode;
+
+const CPI_CONTEXT_CTORS = new Set(["new", "new_with_signer"]);
+
+// Field types that carry a verified program identity (Anchor enforces the program ID at deserialize).
+const TYPED_PROGRAM_TYPES = new Set(["Program", "Interface"]);
+
+// Field types that don't enforce program identity on their own.
+const UNTYPED_PROGRAM_TYPES = new Set(["AccountInfo", "UncheckedAccount"]);
+
+function isCpiContextCall(call: Node): boolean {
+  const fn = call.childForFieldName("function");
+  if (!fn) return false;
+  if (fn.type !== "scoped_identifier") return false;
+  // scoped_identifier { "CpiContext", "::", "new" }
+  const head = fn.namedChild(0);
+  if (head?.text !== "CpiContext") return false;
+  const tail = fn.lastChild;
+  return !!tail && CPI_CONTEXT_CTORS.has(tail.text);
+}
+
+function callArgsFirst(call: Node): Node | null {
+  const args = call.childForFieldName("arguments");
+  if (!args) return null;
+  return args.namedChild(0);
+}
+
+function unwrapAccountInfoCall(arg: Node): Node | null {
+  // Anchor convention: `ctx.accounts.<x>.to_account_info()`. Step into the call to reach the field access.
+  if (arg.type !== "call_expression") return arg;
+  const fn = arg.childForFieldName("function");
+  if (!fn || fn.type !== "field_expression") return null;
+  const method = fn.childForFieldName("field");
+  if (method?.text !== "to_account_info") return null;
+  return fn.childForFieldName("value");
+}
+
+function programArgUsesHardcodedId(arg: Node): boolean {
+  let found = false;
+  walk(arg, n => {
+    if (found) return "skip";
+    if (n.type !== "scoped_identifier") return;
+    let last: Node | null = null;
+    for (let i = 0; i < n.namedChildCount; i++) {
+      const c = n.namedChild(i);
+      if (c) last = c;
+    }
+    if (last && (last.text === "ID" || last.text === "id")) found = true;
+  });
+  return found;
+}
+
+export const anchorCpiContextUnverified: Visitor = {
+  name: "anchor-cpi-context-unverified",
+  severity: "high",
+  appliesTo: ["anchor"],
+  enter: {
+    call_expression(node, ctx) {
+      if (!isInsideProgramModule(node, ctx.anchor.programModule)) return;
+      if (!isCpiContextCall(node)) return;
+      const first = callArgsFirst(node);
+      if (!first) return;
+      if (programArgUsesHardcodedId(first)) return;
+      const target = unwrapAccountInfoCall(first);
+      if (!target) {
+        // Conservative: unknown shape, don't fire.
+        return;
+      }
+      const field = ctxAccountsField(target);
+      if (!field) return;
+      const candidates = findFieldsByName(ctx.anchor.structs, field);
+      if (candidates.length === 0) return;
+      // Fire when EVERY candidate field is untyped (AccountInfo / UncheckedAccount).
+      // If any candidate uses a typed program wrapper (Program / Interface), assume the program identity is enforced.
+      const allUntyped = candidates.every(
+        f => f.typeIdentifier !== null && UNTYPED_PROGRAM_TYPES.has(f.typeIdentifier),
+      );
+      const someTyped = candidates.some(f => f.typeIdentifier !== null && TYPED_PROGRAM_TYPES.has(f.typeIdentifier));
+      if (someTyped || !allUntyped) return;
+      const fn = node.childForFieldName("function");
+      const tail = fn?.lastChild?.text ?? "new";
+      ctx.output.issues.push({
+        severity: "high",
+        rule: "anchor-cpi-context-unverified",
+        title: `CpiContext::${tail} uses untyped program account ${field}`,
+        location: formatLocation(ctx.filename, node),
+        description: `\`CpiContext::${tail}\` is called with \`ctx.accounts.${field}.to_account_info()\` but \`${field}\` is typed as \`AccountInfo\` / \`UncheckedAccount\`. The Anchor runtime cannot verify the program ID before invoking the CPI — an attacker can swap in a malicious program.`,
+        suggestion: `Change the \`${field}\` field type to \`Program<'info, T>\` (or \`Interface<'info, T>\` for Token-2022 compatible APIs), so Anchor enforces the program ID on deserialize.`,
+      });
+    },
+  },
+};

--- a/lib/tools/rustAutofixer/visitors/anchor-cpi-context-unverified.ts
+++ b/lib/tools/rustAutofixer/visitors/anchor-cpi-context-unverified.ts
@@ -1,7 +1,7 @@
 import type Parser from "web-tree-sitter";
 import type { Visitor } from "../types.js";
 import { formatLocation } from "../types.js";
-import { ctxAccountsField, findFieldsByName, isInsideProgramModule } from "./_anchor-helpers.js";
+import { ctxAccountsField, findFieldsForHandlerContext, isInsideProgramModule } from "./_anchor-helpers.js";
 import { walk } from "../walk.js";
 
 type Node = Parser.SyntaxNode;
@@ -74,7 +74,7 @@ export const anchorCpiContextUnverified: Visitor = {
       }
       const field = ctxAccountsField(target);
       if (!field) return;
-      const candidates = findFieldsByName(ctx.anchor.structs, field);
+      const candidates = findFieldsForHandlerContext(ctx.anchor, node, field);
       if (candidates.length === 0) return;
       // Fire when EVERY candidate field is untyped (AccountInfo / UncheckedAccount).
       // If any candidate uses a typed program wrapper (Program / Interface), assume the program identity is enforced.

--- a/lib/tools/rustAutofixer/visitors/anchor-missing-mut.ts
+++ b/lib/tools/rustAutofixer/visitors/anchor-missing-mut.ts
@@ -1,7 +1,7 @@
 import type Parser from "web-tree-sitter";
 import type { Visitor, VisitorContext } from "../types.js";
 import { formatLocation } from "../types.js";
-import { ctxAccountsField, findFieldsByName, isInsideProgramModule } from "./_anchor-helpers.js";
+import { ctxAccountsField, findFieldsForHandlerContext, isInsideProgramModule } from "./_anchor-helpers.js";
 import { getMethodCallName } from "./_helpers.js";
 
 type Node = Parser.SyntaxNode;
@@ -27,7 +27,7 @@ function getState(ctx: VisitorContext): MissingMutState {
 }
 
 function emitIfFieldLacksMut(node: Node, fieldName: string, ctx: VisitorContext): void {
-  const candidates = findFieldsByName(ctx.anchor.structs, fieldName);
+  const candidates = findFieldsForHandlerContext(ctx.anchor, node, fieldName);
   if (candidates.length === 0) return;
   // Conservative: only fire when EVERY matching field lacks `mut`. Avoids cross-struct ambiguity FPs.
   const anyMut = candidates.some(f => f.attribute?.keywords.has("mut"));

--- a/lib/tools/rustAutofixer/visitors/anchor-missing-mut.ts
+++ b/lib/tools/rustAutofixer/visitors/anchor-missing-mut.ts
@@ -1,0 +1,98 @@
+import type Parser from "web-tree-sitter";
+import type { Visitor, VisitorContext } from "../types.js";
+import { formatLocation } from "../types.js";
+import { ctxAccountsField, findFieldsByName, isInsideProgramModule } from "./_anchor-helpers.js";
+import { getMethodCallName } from "./_helpers.js";
+
+type Node = Parser.SyntaxNode;
+
+const MUTATING_METHODS = new Set([
+  "set_lamports",
+  "realloc",
+  "assign",
+  "close",
+  "try_borrow_mut_data",
+  "try_borrow_mut_lamports",
+  "set_inner",
+]);
+
+interface MissingMutState {
+  reported: Set<string>; // location keys to dedupe
+}
+
+function getState(ctx: VisitorContext): MissingMutState {
+  const bag = ctx as unknown as { __anchorMissingMut?: MissingMutState };
+  if (!bag.__anchorMissingMut) bag.__anchorMissingMut = { reported: new Set<string>() };
+  return bag.__anchorMissingMut;
+}
+
+function emitIfFieldLacksMut(node: Node, fieldName: string, ctx: VisitorContext): void {
+  const candidates = findFieldsByName(ctx.anchor.structs, fieldName);
+  if (candidates.length === 0) return;
+  // Conservative: only fire when EVERY matching field lacks `mut`. Avoids cross-struct ambiguity FPs.
+  const anyMut = candidates.some(f => f.attribute?.keywords.has("mut"));
+  if (anyMut) return;
+  // `init` / `init_if_needed` / `close` implicitly grant mutability — Anchor doesn't require explicit `mut`.
+  const anyImplicitMut = candidates.some(
+    f =>
+      f.attribute?.keywords.has("init") ||
+      f.attribute?.keywords.has("init_if_needed") ||
+      f.attribute?.kvPairs.has("close"),
+  );
+  if (anyImplicitMut) return;
+  // Skip Signer / typed program fields — they're typically read-only by convention.
+  const allReadOnlyByType = candidates.every(f => {
+    const t = f.typeIdentifier;
+    return t === "Signer" || t === "Program" || t === "Sysvar" || t === "Interface";
+  });
+  if (allReadOnlyByType) return;
+  const location = formatLocation(ctx.filename, node);
+  const state = getState(ctx);
+  const dedupeKey = `${fieldName}|${location}`;
+  if (state.reported.has(dedupeKey)) return;
+  state.reported.add(dedupeKey);
+  ctx.output.issues.push({
+    severity: "high",
+    rule: "anchor-missing-mut",
+    title: `Mutation of ctx.accounts.${fieldName} without \`mut\` constraint`,
+    location,
+    description: `\`ctx.accounts.${fieldName}\` is mutated inside a handler, but the matching field in the Accounts struct does not declare \`mut\` in its \`#[account(...)]\` attribute. Anchor will refuse the write at runtime — at best a hard error, at worst an inconsistency between declared writability and actual usage.`,
+    suggestion: `Add \`mut\` to the \`#[account(...)]\` attribute on the \`${fieldName}\` field (e.g. \`#[account(mut)]\` or \`#[account(mut, ...)]\`).`,
+  });
+}
+
+export const anchorMissingMut: Visitor = {
+  name: "anchor-missing-mut",
+  severity: "high",
+  appliesTo: ["anchor"],
+  enter: {
+    assignment_expression(node, ctx) {
+      if (!isInsideProgramModule(node, ctx.anchor.programModule)) return;
+      const left = node.childForFieldName("left");
+      if (!left) return;
+      const field = ctxAccountsField(left);
+      if (!field) return;
+      emitIfFieldLacksMut(node, field, ctx);
+    },
+    compound_assignment_expr(node, ctx) {
+      if (!isInsideProgramModule(node, ctx.anchor.programModule)) return;
+      const left = node.childForFieldName("left");
+      if (!left) return;
+      const field = ctxAccountsField(left);
+      if (!field) return;
+      emitIfFieldLacksMut(node, field, ctx);
+    },
+    call_expression(node, ctx) {
+      if (!isInsideProgramModule(node, ctx.anchor.programModule)) return;
+      const method = getMethodCallName(node);
+      if (!method || !MUTATING_METHODS.has(method)) return;
+      const fn = node.childForFieldName("function");
+      if (!fn || fn.type !== "field_expression") return;
+      const receiver = fn.childForFieldName("value");
+      if (!receiver) return;
+      const field = ctxAccountsField(receiver);
+      if (!field) return;
+      emitIfFieldLacksMut(node, field, ctx);
+    },
+  },
+};

--- a/lib/tools/rustAutofixer/visitors/index.ts
+++ b/lib/tools/rustAutofixer/visitors/index.ts
@@ -82,20 +82,18 @@ import { anchorCloseWithoutReceiver } from "./anchor-close-without-receiver.js";
  *   account-relationship        → Check 26 (MEDIUM)
  *   account-borrow              → Check 27 (LOW)
  *
- * Anchor (tier 1, attribute-only)
+ * Anchor account constraints
  *   anchor-seeds-without-bump    (HIGH)
  *   anchor-init-without-space    (HIGH)
  *   anchor-init-without-payer    (CRITICAL)
  *   anchor-realloc-incomplete    (MEDIUM)
  *   anchor-unchecked-account     (LOW)
  *
- * Anchor (tier 2, struct + handler scope)
+ * Anchor account types and handler checks
  *   anchor-account-not-interface (MEDIUM) — Account<Mint> / Account<TokenAccount> vs InterfaceAccount
  *   anchor-manual-signer-check   (MEDIUM) — .is_signer access inside #[program] mod
  *   anchor-manual-key-eq         (LOW)    — require_keys_eq! inside #[program] mod
  *   anchor-emit-via-msg          (LOW)    — msg! inside #[program] mod
- *
- * Anchor (tier 3, cross-handler flow)
  *   anchor-missing-mut             (HIGH)     — ctx.accounts.X mutated, struct field lacks `mut`
  *   anchor-cpi-context-unverified  (HIGH)     — CpiContext::new(<untyped account>, ...) without typed Program/Interface
  *   anchor-close-without-receiver  (CRITICAL) — manual lamport drain without `close = ...` constraint

--- a/lib/tools/rustAutofixer/visitors/index.ts
+++ b/lib/tools/rustAutofixer/visitors/index.ts
@@ -35,6 +35,9 @@ import { anchorAccountNotInterface } from "./anchor-account-not-interface.js";
 import { anchorManualSignerCheck } from "./anchor-manual-signer-check.js";
 import { anchorManualKeyEq } from "./anchor-manual-key-eq.js";
 import { anchorEmitViaMsg } from "./anchor-emit-via-msg.js";
+import { anchorMissingMut } from "./anchor-missing-mut.js";
+import { anchorCpiContextUnverified } from "./anchor-cpi-context-unverified.js";
+import { anchorCloseWithoutReceiver } from "./anchor-close-without-receiver.js";
 
 /**
  * 27-check visitor registry. Each entry maps to a numbered check in
@@ -91,6 +94,11 @@ import { anchorEmitViaMsg } from "./anchor-emit-via-msg.js";
  *   anchor-manual-signer-check   (MEDIUM) — .is_signer access inside #[program] mod
  *   anchor-manual-key-eq         (LOW)    — require_keys_eq! inside #[program] mod
  *   anchor-emit-via-msg          (LOW)    — msg! inside #[program] mod
+ *
+ * Anchor (tier 3, cross-handler flow)
+ *   anchor-missing-mut             (HIGH)     — ctx.accounts.X mutated, struct field lacks `mut`
+ *   anchor-cpi-context-unverified  (HIGH)     — CpiContext::new(<untyped account>, ...) without typed Program/Interface
+ *   anchor-close-without-receiver  (CRITICAL) — manual lamport drain without `close = ...` constraint
  */
 export const allVisitors: readonly Visitor[] = [
   missingSigner,
@@ -129,4 +137,7 @@ export const allVisitors: readonly Visitor[] = [
   anchorManualSignerCheck,
   anchorManualKeyEq,
   anchorEmitViaMsg,
+  anchorMissingMut,
+  anchorCpiContextUnverified,
+  anchorCloseWithoutReceiver,
 ];

--- a/tests/unit/rustAutofixer/fixtures-anchor.ts
+++ b/tests/unit/rustAutofixer/fixtures-anchor.ts
@@ -1,4 +1,4 @@
-// Fixtures for Anchor tier-1 visitors (attribute-only).
+// Fixtures for Anchor visitors.
 // Each pair: vulnerable + secure, framework: "anchor".
 
 const ANCHOR_HEADER = `use anchor_lang::prelude::*;\n`;
@@ -84,6 +84,23 @@ pub struct Init<'info> {
 pub struct Escrow { pub admin: Pubkey }
 `;
 
+export const VULNERABLE_NESTED_INIT_WITHOUT_PAYER = `${ANCHOR_HEADER}
+pub mod accounts {
+  use super::*;
+
+  #[derive(Accounts)]
+  pub struct Init<'info> {
+    #[account(init, space = 8 + 32)]
+    pub escrow: Account<'info, Escrow>,
+    #[account(mut)]
+    pub admin: Signer<'info>,
+    pub system_program: Program<'info, System>,
+  }
+}
+#[account]
+pub struct Escrow { pub admin: Pubkey }
+`;
+
 // ---------- anchor-realloc-incomplete ----------
 export const VULNERABLE_REALLOC_INCOMPLETE = `${ANCHOR_HEADER}
 #[derive(Accounts)]
@@ -111,7 +128,7 @@ pub struct Grow<'info> {
 pub struct Escrow { pub admin: Pubkey }
 `;
 
-// ---------- anchor-account-not-interface (tier 2) ----------
+// ---------- anchor-account-not-interface ----------
 export const VULNERABLE_ACCOUNT_NOT_INTERFACE = `${ANCHOR_HEADER}
 use anchor_spl::token::{Mint, TokenAccount};
 #[derive(Accounts)]
@@ -132,7 +149,7 @@ pub struct Use<'info> {
 }
 `;
 
-// ---------- anchor-manual-signer-check (tier 2) ----------
+// ---------- anchor-manual-signer-check ----------
 export const VULNERABLE_MANUAL_SIGNER_CHECK = `${ANCHOR_HEADER}
 #[derive(Accounts)]
 pub struct Ctx<'info> {
@@ -166,7 +183,7 @@ pub mod my_program {
 }
 `;
 
-// ---------- anchor-manual-key-eq (tier 2) ----------
+// ---------- anchor-manual-key-eq ----------
 export const VULNERABLE_MANUAL_KEY_EQ = `${ANCHOR_HEADER}
 #[derive(Accounts)]
 pub struct Ctx<'info> {
@@ -203,7 +220,7 @@ pub mod my_program {
 pub struct State { pub authority: Pubkey }
 `;
 
-// ---------- anchor-emit-via-msg (tier 2) ----------
+// ---------- anchor-emit-via-msg ----------
 export const VULNERABLE_EMIT_VIA_MSG = `${ANCHOR_HEADER}
 #[derive(Accounts)]
 pub struct Ctx<'info> {
@@ -236,7 +253,7 @@ pub mod my_program {
 }
 `;
 
-// ---------- anchor-missing-mut (tier 3) ----------
+// ---------- anchor-missing-mut ----------
 export const VULNERABLE_MISSING_MUT = `${ANCHOR_HEADER}
 #[derive(Accounts)]
 pub struct Ctx<'info> {
@@ -274,7 +291,48 @@ pub mod my_program {
 pub struct State { pub value: u64 }
 `;
 
-// ---------- anchor-cpi-context-unverified (tier 3) ----------
+export const VULNERABLE_MISSING_MUT_DUPLICATE_FIELD = `${ANCHOR_HEADER}
+#[derive(Accounts)]
+pub struct Good<'info> {
+  #[account(mut)]
+  pub state: Account<'info, State>,
+}
+#[derive(Accounts)]
+pub struct Bad<'info> {
+  pub state: Account<'info, State>,
+}
+#[program]
+pub mod my_program {
+  use super::*;
+  pub fn run(ctx: Context<Bad>, new_value: u64) -> Result<()> {
+    ctx.accounts.state.value = new_value;
+    Ok(())
+  }
+}
+#[account]
+pub struct State { pub value: u64 }
+`;
+
+export const SECURE_LOCAL_FIELD_MUTATION = `${ANCHOR_HEADER}
+#[derive(Accounts)]
+pub struct Ctx<'info> {
+  pub balance: Account<'info, State>,
+}
+pub struct Scratch { pub balance: u64 }
+#[program]
+pub mod my_program {
+  use super::*;
+  pub fn run(_ctx: Context<Ctx>, new_value: u64) -> Result<()> {
+    let mut scratch = Scratch { balance: 0 };
+    scratch.balance = new_value;
+    Ok(())
+  }
+}
+#[account]
+pub struct State { pub value: u64 }
+`;
+
+// ---------- anchor-cpi-context-unverified ----------
 export const VULNERABLE_CPI_UNVERIFIED = `${ANCHOR_HEADER}
 #[derive(Accounts)]
 pub struct Ctx<'info> {
@@ -314,7 +372,30 @@ struct Empty;
 fn invoke_helper<T>(_c: CpiContext<T>) -> Result<()> { Ok(()) }
 `;
 
-// ---------- anchor-close-without-receiver (tier 3) ----------
+export const VULNERABLE_CPI_UNVERIFIED_DUPLICATE_FIELD = `${ANCHOR_HEADER}
+use anchor_spl::token::Token;
+#[derive(Accounts)]
+pub struct Good<'info> {
+  pub token_program: Program<'info, Token>,
+}
+#[derive(Accounts)]
+pub struct Bad<'info> {
+  pub token_program: AccountInfo<'info>,
+}
+#[program]
+pub mod my_program {
+  use super::*;
+  pub fn run(ctx: Context<Bad>) -> Result<()> {
+    let cpi_ctx = CpiContext::new(ctx.accounts.token_program.to_account_info(), Empty {});
+    invoke_helper(cpi_ctx)?;
+    Ok(())
+  }
+}
+struct Empty;
+fn invoke_helper<T>(_c: CpiContext<T>) -> Result<()> { Ok(()) }
+`;
+
+// ---------- anchor-close-without-receiver ----------
 export const VULNERABLE_CLOSE_MANUAL = `${ANCHOR_HEADER}
 #[derive(Accounts)]
 pub struct Ctx<'info> {
@@ -331,6 +412,33 @@ pub mod my_program {
     let from = ctx.accounts.escrow.to_account_info();
     let dest = ctx.accounts.receiver.to_account_info();
     **dest.lamports.borrow_mut() = dest.lamports().checked_add(from.lamports()).unwrap();
+    **ctx.accounts.escrow.to_account_info().lamports.borrow_mut() = 0;
+    Ok(())
+  }
+}
+#[account]
+pub struct Escrow { pub admin: Pubkey }
+`;
+
+export const VULNERABLE_CLOSE_MANUAL_DUPLICATE_FIELD = `${ANCHOR_HEADER}
+#[derive(Accounts)]
+pub struct Good<'info> {
+  #[account(mut, close = receiver)]
+  pub escrow: Account<'info, Escrow>,
+  #[account(mut)]
+  pub receiver: AccountInfo<'info>,
+}
+#[derive(Accounts)]
+pub struct Bad<'info> {
+  #[account(mut)]
+  pub escrow: Account<'info, Escrow>,
+  #[account(mut)]
+  pub receiver: AccountInfo<'info>,
+}
+#[program]
+pub mod my_program {
+  use super::*;
+  pub fn close_it(ctx: Context<Bad>) -> Result<()> {
     **ctx.accounts.escrow.to_account_info().lamports.borrow_mut() = 0;
     Ok(())
   }

--- a/tests/unit/rustAutofixer/fixtures-anchor.ts
+++ b/tests/unit/rustAutofixer/fixtures-anchor.ts
@@ -236,6 +236,127 @@ pub mod my_program {
 }
 `;
 
+// ---------- anchor-missing-mut (tier 3) ----------
+export const VULNERABLE_MISSING_MUT = `${ANCHOR_HEADER}
+#[derive(Accounts)]
+pub struct Ctx<'info> {
+  pub state: Account<'info, State>,
+  pub admin: Signer<'info>,
+}
+#[program]
+pub mod my_program {
+  use super::*;
+  pub fn run(ctx: Context<Ctx>, new_value: u64) -> Result<()> {
+    ctx.accounts.state.value = new_value;
+    Ok(())
+  }
+}
+#[account]
+pub struct State { pub value: u64 }
+`;
+
+export const SECURE_MUT_CONSTRAINT = `${ANCHOR_HEADER}
+#[derive(Accounts)]
+pub struct Ctx<'info> {
+  #[account(mut)]
+  pub state: Account<'info, State>,
+  pub admin: Signer<'info>,
+}
+#[program]
+pub mod my_program {
+  use super::*;
+  pub fn run(ctx: Context<Ctx>, new_value: u64) -> Result<()> {
+    ctx.accounts.state.value = new_value;
+    Ok(())
+  }
+}
+#[account]
+pub struct State { pub value: u64 }
+`;
+
+// ---------- anchor-cpi-context-unverified (tier 3) ----------
+export const VULNERABLE_CPI_UNVERIFIED = `${ANCHOR_HEADER}
+#[derive(Accounts)]
+pub struct Ctx<'info> {
+  pub token_program: AccountInfo<'info>,
+  pub admin: Signer<'info>,
+}
+#[program]
+pub mod my_program {
+  use super::*;
+  pub fn run(ctx: Context<Ctx>) -> Result<()> {
+    let cpi_ctx = CpiContext::new(ctx.accounts.token_program.to_account_info(), Empty {});
+    invoke_helper(cpi_ctx)?;
+    Ok(())
+  }
+}
+struct Empty;
+fn invoke_helper<T>(_c: CpiContext<T>) -> Result<()> { Ok(()) }
+`;
+
+export const SECURE_CPI_TYPED_PROGRAM = `${ANCHOR_HEADER}
+use anchor_spl::token::Token;
+#[derive(Accounts)]
+pub struct Ctx<'info> {
+  pub token_program: Program<'info, Token>,
+  pub admin: Signer<'info>,
+}
+#[program]
+pub mod my_program {
+  use super::*;
+  pub fn run(ctx: Context<Ctx>) -> Result<()> {
+    let cpi_ctx = CpiContext::new(ctx.accounts.token_program.to_account_info(), Empty {});
+    invoke_helper(cpi_ctx)?;
+    Ok(())
+  }
+}
+struct Empty;
+fn invoke_helper<T>(_c: CpiContext<T>) -> Result<()> { Ok(()) }
+`;
+
+// ---------- anchor-close-without-receiver (tier 3) ----------
+export const VULNERABLE_CLOSE_MANUAL = `${ANCHOR_HEADER}
+#[derive(Accounts)]
+pub struct Ctx<'info> {
+  #[account(mut)]
+  pub escrow: Account<'info, Escrow>,
+  #[account(mut)]
+  pub receiver: AccountInfo<'info>,
+  pub admin: Signer<'info>,
+}
+#[program]
+pub mod my_program {
+  use super::*;
+  pub fn close_it(ctx: Context<Ctx>) -> Result<()> {
+    let from = ctx.accounts.escrow.to_account_info();
+    let dest = ctx.accounts.receiver.to_account_info();
+    **dest.lamports.borrow_mut() = dest.lamports().checked_add(from.lamports()).unwrap();
+    **ctx.accounts.escrow.to_account_info().lamports.borrow_mut() = 0;
+    Ok(())
+  }
+}
+#[account]
+pub struct Escrow { pub admin: Pubkey }
+`;
+
+export const SECURE_CLOSE_CONSTRAINT = `${ANCHOR_HEADER}
+#[derive(Accounts)]
+pub struct Ctx<'info> {
+  #[account(mut, close = receiver)]
+  pub escrow: Account<'info, Escrow>,
+  #[account(mut)]
+  pub receiver: AccountInfo<'info>,
+  pub admin: Signer<'info>,
+}
+#[program]
+pub mod my_program {
+  use super::*;
+  pub fn close_it(_ctx: Context<Ctx>) -> Result<()> { Ok(()) }
+}
+#[account]
+pub struct Escrow { pub admin: Pubkey }
+`;
+
 // ---------- anchor-unchecked-account ----------
 export const VULNERABLE_UNCHECKED_ACCOUNT = `${ANCHOR_HEADER}
 #[derive(Accounts)]

--- a/tests/unit/rustAutofixer/visitors-anchor.test.ts
+++ b/tests/unit/rustAutofixer/visitors-anchor.test.ts
@@ -7,6 +7,7 @@ import {
   SECURE_INIT_WITH_SPACE,
   VULNERABLE_INIT_WITHOUT_PAYER,
   SECURE_INIT_WITH_PAYER,
+  VULNERABLE_NESTED_INIT_WITHOUT_PAYER,
   VULNERABLE_REALLOC_INCOMPLETE,
   SECURE_REALLOC_COMPLETE,
   VULNERABLE_UNCHECKED_ACCOUNT,
@@ -21,10 +22,14 @@ import {
   SECURE_EMIT,
   VULNERABLE_MISSING_MUT,
   SECURE_MUT_CONSTRAINT,
+  VULNERABLE_MISSING_MUT_DUPLICATE_FIELD,
+  SECURE_LOCAL_FIELD_MUTATION,
   VULNERABLE_CPI_UNVERIFIED,
   SECURE_CPI_TYPED_PROGRAM,
+  VULNERABLE_CPI_UNVERIFIED_DUPLICATE_FIELD,
   VULNERABLE_CLOSE_MANUAL,
   SECURE_CLOSE_CONSTRAINT,
+  VULNERABLE_CLOSE_MANUAL_DUPLICATE_FIELD,
 } from "./fixtures-anchor.js";
 
 const PAIRS: ReadonlyArray<{
@@ -62,7 +67,7 @@ const PAIRS: ReadonlyArray<{
   },
 ];
 
-describe("rust_autofixer Anchor tier-1 visitors", () => {
+describe("rust_autofixer Anchor visitors", () => {
   it.each(PAIRS)(
     "$rule fires on vulnerable Anchor fixture",
     async ({ rule, vulnerable }) => {
@@ -83,9 +88,44 @@ describe("rust_autofixer Anchor tier-1 visitors", () => {
     20_000,
   );
 
-  it("auto-detects Anchor and runs tier-1 visitors", async () => {
+  it("auto-detects Anchor and runs Anchor visitors", async () => {
     const out = await runRustAutofixer({ code: VULNERABLE_INIT_WITHOUT_PAYER, framework: "auto" });
     const hit = out.issues.find(i => i.rule === "anchor-init-without-payer");
-    expect(hit, "auto-detect failed to identify Anchor + run tier-1 visitors").toBeDefined();
+    expect(hit, "auto-detect failed to identify Anchor + run Anchor visitors").toBeDefined();
+  }, 20_000);
+
+  it("collects Accounts derives nested inside modules", async () => {
+    const out = await runRustAutofixer({ code: VULNERABLE_NESTED_INIT_WITHOUT_PAYER, framework: "anchor" });
+    const hit = out.issues.find(i => i.rule === "anchor-init-without-payer");
+    expect(hit, "nested #[derive(Accounts)] struct was not analyzed").toBeDefined();
+  }, 20_000);
+
+  it.each([
+    {
+      rule: "anchor-missing-mut",
+      code: VULNERABLE_MISSING_MUT_DUPLICATE_FIELD,
+    },
+    {
+      rule: "anchor-cpi-context-unverified",
+      code: VULNERABLE_CPI_UNVERIFIED_DUPLICATE_FIELD,
+    },
+    {
+      rule: "anchor-close-without-receiver",
+      code: VULNERABLE_CLOSE_MANUAL_DUPLICATE_FIELD,
+    },
+  ])(
+    "resolves duplicate account field names through handler Context<T> for $rule",
+    async ({ rule, code }) => {
+      const out = await runRustAutofixer({ code, framework: "anchor" });
+      const hit = out.issues.find(i => i.rule === rule);
+      expect(hit, `${rule} was masked by another Accounts struct with the same field name`).toBeDefined();
+    },
+    20_000,
+  );
+
+  it("does not treat local field mutations as ctx.accounts mutations", async () => {
+    const out = await runRustAutofixer({ code: SECURE_LOCAL_FIELD_MUTATION, framework: "anchor" });
+    const hit = out.issues.find(i => i.rule === "anchor-missing-mut");
+    expect(hit, `local field mutation was reported as an account mutation: ${hit?.title}`).toBeUndefined();
   }, 20_000);
 });

--- a/tests/unit/rustAutofixer/visitors-anchor.test.ts
+++ b/tests/unit/rustAutofixer/visitors-anchor.test.ts
@@ -19,6 +19,12 @@ import {
   SECURE_HAS_ONE,
   VULNERABLE_EMIT_VIA_MSG,
   SECURE_EMIT,
+  VULNERABLE_MISSING_MUT,
+  SECURE_MUT_CONSTRAINT,
+  VULNERABLE_CPI_UNVERIFIED,
+  SECURE_CPI_TYPED_PROGRAM,
+  VULNERABLE_CLOSE_MANUAL,
+  SECURE_CLOSE_CONSTRAINT,
 } from "./fixtures-anchor.js";
 
 const PAIRS: ReadonlyArray<{
@@ -43,6 +49,17 @@ const PAIRS: ReadonlyArray<{
   },
   { rule: "anchor-manual-key-eq", vulnerable: VULNERABLE_MANUAL_KEY_EQ, secure: SECURE_HAS_ONE },
   { rule: "anchor-emit-via-msg", vulnerable: VULNERABLE_EMIT_VIA_MSG, secure: SECURE_EMIT },
+  { rule: "anchor-missing-mut", vulnerable: VULNERABLE_MISSING_MUT, secure: SECURE_MUT_CONSTRAINT },
+  {
+    rule: "anchor-cpi-context-unverified",
+    vulnerable: VULNERABLE_CPI_UNVERIFIED,
+    secure: SECURE_CPI_TYPED_PROGRAM,
+  },
+  {
+    rule: "anchor-close-without-receiver",
+    vulnerable: VULNERABLE_CLOSE_MANUAL,
+    secure: SECURE_CLOSE_CONSTRAINT,
+  },
 ];
 
 describe("rust_autofixer Anchor tier-1 visitors", () => {


### PR DESCRIPTION
> **Stacked on #90.** Base: `feat/rust-autofixer-anchor-tier-1`. Merge #89 → #90 → this in order.

## Summary
- 3 Anchor visitors that bridge Accounts-struct declarations with handler-body usage, completing the tier-1/2/3 coverage planned in `rust-autofixer-anchor-coverage.md`.
- Pure AST. Cross-struct lookups are intentionally conservative — fire only when EVERY matching field lacks the relevant constraint, to avoid name-collision false positives.
- Reuses the `ctx.anchor` cache built in tier 1. Adds `ctxAccountsField`, `collectCtxAccountsAccesses`, and `findFieldsByName` helpers.

## Tier 3 — cross-handler flow
| Rule | Severity | Trigger |
|---|---|---|
| `anchor-missing-mut` | HIGH | `ctx.accounts.X` mutated in handler but field declares neither `mut` nor an implicit-mut keyword (`init`, `init_if_needed`, `close`) |
| `anchor-cpi-context-unverified` | HIGH | `CpiContext::new` / `new_with_signer` called with `ctx.accounts.X.to_account_info()` where `X` is `AccountInfo` / `UncheckedAccount` (no typed Program / Interface) |
| `anchor-close-without-receiver` | CRITICAL | handler assigns `0` to a lamports-touching LHS without the Accounts struct declaring `#[account(close = <receiver>)]` on the involved field |

## Test Plan
- `pnpm test:integration` — 189 tests across 18 files (3 new vulnerable + secure pairs)
- `pnpm typecheck` / `pnpm lint` — clean
- Live-tested against `coral-xyz/anchor` test programs:
  - `relations-derivation`: 7 `anchor-unchecked-account` (unchanged, no tier-3 hits)
  - `lockup`: **3 `anchor-missing-mut`** (real) on top of tier-1/2 catches
  - `bpf-upgradeable-state`: clean (0 hits)

## False-positive mitigation
- Discovered during live testing that Anchor's `init` / `init_if_needed` / `close` constraints implicitly grant mutability. Visitor now skips when any matching field carries one of those — eliminated 4 FPs on `bpf-upgradeable-state` (2 hits → 0) and `relations-derivation` (9 hits → 7).
- `Signer<'info>`, `Program<'info, T>`, `Sysvar<'info, T>`, `Interface<'info, T>` field types are also skipped — read-only by convention.

## Implementation notes
- `ctxAccountsField(node)` walks a `field_expression` chain looking for a `ctx.accounts.X.Y...` shape, returns `X`. Pure AST, no string parsing.
- `anchor-close-without-receiver` is the most conservative — fires only when the LHS of an `assignment_expression` literally contains a `lamports` identifier (any depth) and the RHS is `0` (or `(0)`).
- `anchor-cpi-context-unverified` only fires when the program arg is `ctx.accounts.X.to_account_info()` AND `X` resolves to an untyped account type AND no hard-coded `::ID` appears anywhere in the call. Avoids touching unfamiliar shapes.

## Stack
- #89 = Pinocchio v1 (27 visitors) — base
- #90 = Anchor tier-1 + tier-2 (9 visitors)
- **This PR = Anchor tier-3 (3 visitors)** — completes the planned Anchor coverage

Once all three land, the `rust_autofixer` tool covers 39 visitors total across Pinocchio + Anchor.