### PR TITLE
fix(analytics): revert databricks batching

### DIFF
--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -78,7 +78,7 @@ export async function logAnalytics(event: AnalyticsEvent) {
       switch (parsedBody.method) {
         case "initialize": {
           const { protocolVersion, capabilities, clientInfo } = parsedBody.params || {};
-          databricksAnalytics.logInitialization({
+          await databricksAnalytics.logInitialization({
             protocolVersion,
             capabilities,
             clientName: clientInfo?.name || "",
@@ -92,7 +92,7 @@ export async function logAnalytics(event: AnalyticsEvent) {
           const { name, arguments: toolArgs } = parsedBody.params || {};
           const toolName = typeof name === "string" ? name : "";
           const sanitizedArgs = sanitizeToolArgs(toolName, toolArgs);
-          databricksAnalytics.logToolCallRequest({
+          await databricksAnalytics.logToolCallRequest({
             toolName,
             requestId: event.request_id ?? null,
             sessionId: event.session_id ?? null,
@@ -113,8 +113,4 @@ export async function logAnalytics(event: AnalyticsEvent) {
   } catch (err) {
     console.error("[logAnalytics] Unexpected error:", err);
   }
-}
-
-export async function flushAnalytics(): Promise<void> {
-  await databricksAnalytics.flushAnalytics();
 }

--- a/lib/services/databricks/analytics.ts
+++ b/lib/services/databricks/analytics.ts
@@ -1,5 +1,4 @@
 import { dbxFetch, isDatabricksConfigured } from "./client.js";
-import { sleep } from "./utils.js";
 
 // Schema hosting the analytics tables. Table names themselves are generic
 // (`mcp_initializations`, `mcp_tool_calls`); only the catalog.schema prefix
@@ -24,48 +23,11 @@ interface SqlExecuteRequest {
   wait_timeout: string;
 }
 
-interface SqlExecuteResponse {
-  status?: { state?: string; error?: { message?: string } };
-  statement_id?: string;
+interface InsertColumn {
+  col: string;
+  param: string;
+  value: string | null;
 }
-
-type AnalyticsTable = "mcp_initializations" | "mcp_tool_calls";
-type BufferTrimSide = "newest" | "oldest";
-
-type RowValues = Record<string, string | null>;
-
-interface BufferedRow {
-  timestamp: string;
-  values: RowValues;
-}
-
-interface InsertChunk {
-  rows: BufferedRow[];
-  request: SqlExecuteRequest;
-}
-
-const DEFAULT_BATCH_SIZE = 1_000;
-const DEFAULT_FLUSH_INTERVAL_MS = 60 * 60 * 1_000;
-const DEFAULT_INSERT_CHUNK_BYTE_LIMIT = 24 * 1_024;
-const DEFAULT_INSERT_CHUNK_ROW_LIMIT = 20;
-const DEFAULT_MAX_BUFFERED_ROWS = 10_000;
-const STATEMENT_TIMEOUT = "30s";
-const POLL_MAX_ATTEMPTS = 6;
-const POLL_BACKOFF_MS = [500, 1000, 2000, 4000, 8000, 8000];
-
-const TABLE_COLUMNS: Record<AnalyticsTable, readonly string[]> = {
-  mcp_initializations: ["method", "protocol_version", "capabilities", "client_name", "client_version", "raw_body"],
-  mcp_tool_calls: ["row_type", "tool_name", "request_id", "session_id", "arguments", "response_text", "raw_body"],
-};
-
-const buffers: Record<AnalyticsTable, BufferedRow[]> = {
-  mcp_initializations: [],
-  mcp_tool_calls: [],
-};
-
-let flushTimer: NodeJS.Timeout | null = null;
-let flushInFlight: Promise<void> | null = null;
-const warningKeys = new Set<string>();
 
 function resolveWarehouse(): string | null {
   if (!isDatabricksConfigured()) return null;
@@ -82,184 +44,52 @@ function assertIdent(kind: string, value: string): void {
   }
 }
 
-function readPositiveInt(name: string, fallback: number): number {
-  const raw = process.env[name];
-  if (!raw) return fallback;
-  const parsed = Number(raw);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-function batchSize(): number {
-  return readPositiveInt("DATABRICKS_ANALYTICS_BATCH_SIZE", DEFAULT_BATCH_SIZE);
-}
-
-function flushIntervalMs(): number {
-  return readPositiveInt("DATABRICKS_ANALYTICS_FLUSH_INTERVAL_MS", DEFAULT_FLUSH_INTERVAL_MS);
-}
-
-function insertChunkByteLimit(): number {
-  return readPositiveInt("DATABRICKS_ANALYTICS_INSERT_CHUNK_BYTE_LIMIT", DEFAULT_INSERT_CHUNK_BYTE_LIMIT);
-}
-
-function insertChunkRowLimit(): number {
-  return readPositiveInt("DATABRICKS_ANALYTICS_INSERT_CHUNK_ROW_LIMIT", DEFAULT_INSERT_CHUNK_ROW_LIMIT);
-}
-
-function maxBufferedRows(): number {
-  return readPositiveInt("DATABRICKS_ANALYTICS_MAX_BUFFERED_ROWS", DEFAULT_MAX_BUFFERED_ROWS);
-}
-
-function warnOnce(key: string, message: string): void {
-  if (warningKeys.has(key)) return;
-  warningKeys.add(key);
-  console.warn(message);
-}
-
-function enqueueNamedInsert(table: AnalyticsTable, values: RowValues): void {
+async function executeNamedInsert(table: string, columns: InsertColumn[]): Promise<void> {
   const schema = analyticsSchema();
   if (!schema) {
-    warnOnce("missing-schema", "[analytics] DATABRICKS_ANALYTICS_SCHEMA not set — analytics disabled");
+    console.warn("[analytics] DATABRICKS_ANALYTICS_SCHEMA not set — analytics disabled");
     return;
   }
   const warehouseId = resolveWarehouse();
   if (!warehouseId) {
-    warnOnce("missing-databricks", "[analytics] Databricks env not set — analytics disabled");
+    console.warn("[analytics] Databricks env not set — analytics disabled");
     return;
   }
 
   assertIdent("table", table);
-  for (const col of TABLE_COLUMNS[table]) {
-    assertIdent("column", col);
+  for (const c of columns) {
+    assertIdent("column", c.col);
+    assertIdent("param", c.param);
   }
 
-  buffers[table].push({ timestamp: new Date().toISOString(), values });
-  trimBuffer(table, "oldest");
-  ensureFlushTimer();
-
-  if (bufferedAnalyticsRowCount() >= batchSize()) {
-    void flushAnalytics().catch((err: unknown) => {
-      console.error("[analytics] Error flushing batch:", err);
-    });
-  }
-}
-
-function trimBuffer(table: AnalyticsTable, side: BufferTrimSide): void {
-  const limit = maxBufferedRows();
-  const overflow = buffers[table].length - limit;
-  if (overflow <= 0) return;
-  if (side === "oldest") {
-    buffers[table].splice(0, overflow);
-  } else {
-    buffers[table].splice(-overflow, overflow);
-  }
-  console.warn(`[analytics] dropped ${overflow} buffered ${table} rows after reaching max buffer size`);
-}
-
-function ensureFlushTimer(): void {
-  if (flushTimer) return;
-  flushTimer = setInterval(() => {
-    void flushAnalytics().catch((err: unknown) => {
-      console.error("[analytics] Error flushing batch:", err);
-    });
-  }, flushIntervalMs());
-  flushTimer.unref();
-}
-
-function buildInsertRequest(
-  table: AnalyticsTable,
-  rows: BufferedRow[],
-  warehouseId: string,
-  schema: string,
-): SqlExecuteRequest {
-  const columns = ["timestamp", ...TABLE_COLUMNS[table]];
-  const colList = columns.join(", ");
-  const rowPlaceholders = rows.map((_, rowIndex) => {
-    const placeholders = columns.map(col => {
-      const param = `r${rowIndex}_${col}`;
-      return col === "timestamp" ? `CAST(:${param} AS TIMESTAMP)` : `:${param}`;
-    });
-    return `(${placeholders.join(", ")})`;
-  });
-
+  const colList = ["timestamp", ...columns.map(c => c.col)].join(", ");
+  const placeholders = ["CAST(:timestamp AS TIMESTAMP)", ...columns.map(c => `:${c.param}`)].join(", ");
   const statement = `
     INSERT INTO ${schema}.${table}
       (${colList})
     VALUES
-      ${rowPlaceholders.join(",\n      ")}
+      (${placeholders})
   `;
 
-  const parameters: SqlParam[] = rows.flatMap((row, rowIndex) =>
-    columns.map(col => ({
-      name: `r${rowIndex}_${col}`,
-      value: col === "timestamp" ? row.timestamp : (row.values[col] ?? null),
-      type: "STRING" as const,
-    })),
-  );
+  const parameters: SqlParam[] = [
+    { name: "timestamp", value: new Date().toISOString(), type: "STRING" },
+    ...columns.map(c => ({ name: c.param, value: c.value, type: "STRING" as const })),
+  ];
 
-  return {
+  const body: SqlExecuteRequest = {
     warehouse_id: warehouseId,
     statement,
     parameters,
-    wait_timeout: STATEMENT_TIMEOUT,
+    wait_timeout: "30s",
   };
-}
 
-function requestByteLength(request: SqlExecuteRequest): number {
-  return Buffer.byteLength(JSON.stringify(request), "utf8");
-}
-
-function buildInsertChunks(
-  table: AnalyticsTable,
-  rows: BufferedRow[],
-  warehouseId: string,
-  schema: string,
-): InsertChunk[] {
-  const chunks: InsertChunk[] = [];
-  const byteLimit = insertChunkByteLimit();
-  const rowLimit = insertChunkRowLimit();
-  let chunkRows: BufferedRow[] = [];
-  let chunkRequest: SqlExecuteRequest | null = null;
-
-  for (const row of rows) {
-    const candidateRows = [...chunkRows, row];
-    const candidateRequest = buildInsertRequest(table, candidateRows, warehouseId, schema);
-    const candidateTooLarge = requestByteLength(candidateRequest) > byteLimit || candidateRows.length > rowLimit;
-
-    if (chunkRows.length > 0 && candidateTooLarge) {
-      chunks.push({
-        rows: chunkRows,
-        request: chunkRequest ?? buildInsertRequest(table, chunkRows, warehouseId, schema),
-      });
-      chunkRows = [row];
-      chunkRequest = buildInsertRequest(table, chunkRows, warehouseId, schema);
-      continue;
-    }
-
-    chunkRows = candidateRows;
-    chunkRequest = candidateRequest;
-  }
-
-  if (chunkRows.length > 0) {
-    chunks.push({
-      rows: chunkRows,
-      request: chunkRequest ?? buildInsertRequest(table, chunkRows, warehouseId, schema),
-    });
-  }
-
-  return chunks;
-}
-
-async function executeInsertRequest(request: SqlExecuteRequest): Promise<void> {
-  let res = await dbxFetch<SqlExecuteResponse>("/api/2.0/sql/statements", {
+  const res = await dbxFetch<{
+    status?: { state?: string; error?: { message?: string } };
+    statement_id?: string;
+  }>("/api/2.0/sql/statements", {
     method: "POST",
-    body: JSON.stringify(request),
+    body: JSON.stringify(body),
   });
-
-  for (let attempt = 0; attempt < POLL_MAX_ATTEMPTS && isPending(res.status?.state); attempt++) {
-    if (!res.statement_id) break;
-    await sleep(POLL_BACKOFF_MS[attempt] ?? POLL_BACKOFF_MS[POLL_BACKOFF_MS.length - 1]);
-    res = await dbxFetch<SqlExecuteResponse>(`/api/2.0/sql/statements/${encodeURIComponent(res.statement_id)}`);
-  }
 
   const state = res.status?.state;
   if (state !== "SUCCEEDED") {
@@ -268,119 +98,52 @@ async function executeInsertRequest(request: SqlExecuteRequest): Promise<void> {
   }
 }
 
-function resolveFlushTarget(): { schema: string; warehouseId: string } | null {
-  const schema = analyticsSchema();
-  if (!schema) {
-    warnOnce("missing-schema", "[analytics] DATABRICKS_ANALYTICS_SCHEMA not set — analytics disabled");
-    return null;
-  }
-  const warehouseId = resolveWarehouse();
-  if (!warehouseId) {
-    warnOnce("missing-databricks", "[analytics] Databricks env not set — analytics disabled");
-    return null;
-  }
-  return { schema, warehouseId };
-}
-
-function isPending(state: string | undefined): boolean {
-  return state === "PENDING" || state === "RUNNING";
-}
-
-function requeueRows(table: AnalyticsTable, rows: BufferedRow[]): void {
-  buffers[table] = [...rows, ...buffers[table]];
-  trimBuffer(table, "newest");
-}
-
-async function flushTable(table: AnalyticsTable): Promise<void> {
-  const rows = buffers[table].splice(0, buffers[table].length);
-  if (rows.length === 0) return;
-  const target = resolveFlushTarget();
-  if (!target) {
-    requeueRows(table, rows);
-    return;
-  }
-
-  const chunks = buildInsertChunks(table, rows, target.warehouseId, target.schema);
-  let rowStart = 0;
-  for (const chunk of chunks) {
-    try {
-      await executeInsertRequest(chunk.request);
-    } catch (err) {
-      requeueRows(table, rows.slice(rowStart));
-      throw err;
-    }
-    rowStart += chunk.rows.length;
-  }
-}
-
-export async function flushAnalytics(): Promise<void> {
-  if (flushInFlight) return flushInFlight;
-  flushInFlight = (async () => {
-    try {
-      await flushTable("mcp_initializations");
-      await flushTable("mcp_tool_calls");
-    } finally {
-      flushInFlight = null;
-    }
-  })();
-  return flushInFlight;
-}
-
 function stringify(value: unknown): string {
   return JSON.stringify(value ?? null);
 }
 
-export function logInitialization(params: {
+export async function logInitialization(params: {
   protocolVersion: string;
   capabilities: unknown;
   clientName: string;
   clientVersion: string;
   rawBody: unknown;
-}): void {
-  enqueueNamedInsert("mcp_initializations", {
-    method: "initialize",
-    protocol_version: params.protocolVersion,
-    capabilities: stringify(params.capabilities),
-    client_name: params.clientName,
-    client_version: params.clientVersion,
-    raw_body: stringify(params.rawBody),
-  });
+}): Promise<void> {
+  await executeNamedInsert("mcp_initializations", [
+    { col: "method", param: "method", value: "initialize" },
+    { col: "protocol_version", param: "protocolVersion", value: params.protocolVersion },
+    { col: "capabilities", param: "capabilities", value: stringify(params.capabilities) },
+    { col: "client_name", param: "clientName", value: params.clientName },
+    { col: "client_version", param: "clientVersion", value: params.clientVersion },
+    { col: "raw_body", param: "rawBody", value: stringify(params.rawBody) },
+  ]);
 }
 
-export function logToolCallRequest(params: {
+export async function logToolCallRequest(params: {
   toolName: string;
   requestId: string | null;
   sessionId: string | null;
   toolArgs: unknown;
   rawBody: unknown;
-}): void {
-  enqueueNamedInsert("mcp_tool_calls", {
-    row_type: "request",
-    tool_name: params.toolName,
-    request_id: params.requestId,
-    session_id: params.sessionId,
-    arguments: stringify(params.toolArgs),
-    response_text: null,
-    raw_body: stringify(params.rawBody),
-  });
+}): Promise<void> {
+  await executeNamedInsert("mcp_tool_calls", [
+    { col: "row_type", param: "rowType", value: "request" },
+    { col: "tool_name", param: "toolName", value: params.toolName },
+    { col: "request_id", param: "requestId", value: params.requestId },
+    { col: "session_id", param: "sessionId", value: params.sessionId },
+    { col: "arguments", param: "arguments", value: stringify(params.toolArgs) },
+    { col: "raw_body", param: "rawBody", value: stringify(params.rawBody) },
+  ]);
 }
 
 export function logToolCallResponse(params: { tool: string; req: string; res: string; rawBody: unknown }): void {
-  try {
-    enqueueNamedInsert("mcp_tool_calls", {
-      row_type: "response",
-      tool_name: params.tool,
-      request_id: null,
-      session_id: null,
-      arguments: stringify(params.req),
-      response_text: params.res,
-      raw_body: stringify(params.rawBody),
-    });
-  } catch (err) {
-    console.error("[logToolCallResponse] Error buffering tool response:", err);
-  }
-}
-
-export function bufferedAnalyticsRowCount(): number {
-  return Object.values(buffers).reduce((total, rows) => total + rows.length, 0);
+  executeNamedInsert("mcp_tool_calls", [
+    { col: "row_type", param: "rowType", value: "response" },
+    { col: "tool_name", param: "toolName", value: params.tool },
+    { col: "arguments", param: "arguments", value: stringify(params.req) },
+    { col: "response_text", param: "responseText", value: params.res },
+    { col: "raw_body", param: "rawBody", value: stringify(params.rawBody) },
+  ]).catch((err: unknown) => {
+    console.error("[logToolCallResponse] Error inserting tool response:", err);
+  });
 }

--- a/server/cloudrun.ts
+++ b/server/cloudrun.ts
@@ -2,7 +2,6 @@ import { readFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { join } from "node:path";
 
-import { flushAnalytics } from "../lib/analytics";
 import { handleMcpRequest } from "../lib/handler";
 
 const PORT = Number(process.env.PORT ?? 8080);
@@ -167,14 +166,8 @@ function shutdown(signal: NodeJS.Signals): void {
       process.exit(1);
       return;
     }
-    void flushAnalytics()
-      .catch((flushErr: unknown) => {
-        console.warn("[cloudrun] analytics flush failed during shutdown:", flushErr);
-      })
-      .finally(() => {
-        console.warn("[cloudrun] drained, exiting cleanly");
-        process.exit(0);
-      });
+    console.warn("[cloudrun] drained, exiting cleanly");
+    process.exit(0);
   });
   server.closeIdleConnections();
 }

--- a/tests/unit/databricks.analytics.test.ts
+++ b/tests/unit/databricks.analytics.test.ts
@@ -37,7 +37,7 @@ describe("databricks analytics service", () => {
     vi.resetModules();
     vi.clearAllMocks();
     vi.stubGlobal("fetch", fetchMock);
-    fetchMock.mockImplementation(() => Promise.resolve(jsonResponse({ status: { state: "SUCCEEDED" } })));
+    fetchMock.mockResolvedValue(jsonResponse({ status: { state: "SUCCEEDED" } }));
     process.env.DATABRICKS_HOST = HOST;
     process.env.DATABRICKS_TOKEN = TOKEN;
     process.env.DATABRICKS_WAREHOUSE_ID = WAREHOUSE;
@@ -50,11 +50,6 @@ describe("databricks analytics service", () => {
     delete process.env.DATABRICKS_TOKEN;
     delete process.env.DATABRICKS_WAREHOUSE_ID;
     delete process.env.DATABRICKS_ANALYTICS_SCHEMA;
-    delete process.env.DATABRICKS_ANALYTICS_BATCH_SIZE;
-    delete process.env.DATABRICKS_ANALYTICS_FLUSH_INTERVAL_MS;
-    delete process.env.DATABRICKS_ANALYTICS_INSERT_CHUNK_BYTE_LIMIT;
-    delete process.env.DATABRICKS_ANALYTICS_INSERT_CHUNK_ROW_LIMIT;
-    delete process.env.DATABRICKS_ANALYTICS_MAX_BUFFERED_ROWS;
   });
 
   describe("logInitialization", () => {
@@ -63,7 +58,7 @@ describe("databricks analytics service", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
       const { logInitialization } = await import("../../lib/services/databricks/analytics.js");
 
-      logInitialization({
+      await logInitialization({
         protocolVersion: "2025-03-26",
         capabilities: {},
         clientName: "codex",
@@ -81,7 +76,7 @@ describe("databricks analytics service", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
       const { logInitialization } = await import("../../lib/services/databricks/analytics.js");
 
-      logInitialization({
+      await logInitialization({
         protocolVersion: "2025-03-26",
         capabilities: {},
         clientName: "codex",
@@ -93,11 +88,10 @@ describe("databricks analytics service", () => {
       warnSpy.mockRestore();
     });
 
-    it("buffers initialization rows until flush", async () => {
-      const { bufferedAnalyticsRowCount, flushAnalytics, logInitialization } =
-        await import("../../lib/services/databricks/analytics.js");
+    it("POSTs SQL statement with correct parameters", async () => {
+      const { logInitialization } = await import("../../lib/services/databricks/analytics.js");
 
-      logInitialization({
+      await logInitialization({
         protocolVersion: "2025-03-26",
         capabilities: { roots: { listChanged: true } },
         clientName: "codex",
@@ -105,102 +99,18 @@ describe("databricks analytics service", () => {
         rawBody: { method: "initialize" },
       });
 
-      expect(fetchMock).not.toHaveBeenCalled();
-      expect(bufferedAnalyticsRowCount()).toBe(1);
-
-      await flushAnalytics();
-
       expect(fetchMock).toHaveBeenCalledTimes(1);
       const req = recordedRequest(fetchMock.mock.calls[0] as [string, RequestInit]);
       expect(req.url).toBe(`${HOST}/api/2.0/sql/statements`);
       expect(req.body.warehouse_id).toBe(WAREHOUSE);
       expect(req.body.statement).toContain("mcp_initializations");
 
-      expect(findParam(req, "r0_method")).toBe("initialize");
-      expect(findParam(req, "r0_protocol_version")).toBe("2025-03-26");
-      expect(findParam(req, "r0_client_name")).toBe("codex");
-      expect(findParam(req, "r0_client_version")).toBe("1.2.3");
-      expect(findParam(req, "r0_capabilities")).toBe(JSON.stringify({ roots: { listChanged: true } }));
-      expect(findParam(req, "r0_raw_body")).toBe(JSON.stringify({ method: "initialize" }));
-      expect(bufferedAnalyticsRowCount()).toBe(0);
-    });
-
-    it("flushes automatically when the batch size is reached", async () => {
-      process.env.DATABRICKS_ANALYTICS_BATCH_SIZE = "2";
-      const { logInitialization } = await import("../../lib/services/databricks/analytics.js");
-
-      logInitialization({
-        protocolVersion: "2025-03-26",
-        capabilities: {},
-        clientName: "codex",
-        clientVersion: "1.0.0",
-        rawBody: { id: 1 },
-      });
-      expect(fetchMock).not.toHaveBeenCalled();
-
-      logInitialization({
-        protocolVersion: "2025-03-26",
-        capabilities: {},
-        clientName: "cursor",
-        clientVersion: "2.0.0",
-        rawBody: { id: 2 },
-      });
-
-      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-      const req = recordedRequest(fetchMock.mock.calls[0] as [string, RequestInit]);
-      expect(req.body.parameters).toHaveLength(14);
-      expect(findParam(req, "r0_client_name")).toBe("codex");
-      expect(findParam(req, "r1_client_name")).toBe("cursor");
-    });
-  });
-
-  describe("flush chunking", () => {
-    it("keeps the flush threshold separate from the insert row limit", async () => {
-      process.env.DATABRICKS_ANALYTICS_BATCH_SIZE = "3";
-      process.env.DATABRICKS_ANALYTICS_INSERT_CHUNK_ROW_LIMIT = "2";
-      const { logInitialization } = await import("../../lib/services/databricks/analytics.js");
-
-      for (const clientName of ["codex", "cursor", "claude"]) {
-        logInitialization({
-          protocolVersion: "2025-03-26",
-          capabilities: {},
-          clientName,
-          clientVersion: "1.0.0",
-          rawBody: {},
-        });
-      }
-
-      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-      const firstReq = recordedRequest(fetchMock.mock.calls[0] as [string, RequestInit]);
-      const secondReq = recordedRequest(fetchMock.mock.calls[1] as [string, RequestInit]);
-      expect(findParam(firstReq, "r0_client_name")).toBe("codex");
-      expect(findParam(firstReq, "r1_client_name")).toBe("cursor");
-      expect(findParam(secondReq, "r0_client_name")).toBe("claude");
-    });
-
-    it("splits inserts by serialized request byte limit", async () => {
-      process.env.DATABRICKS_ANALYTICS_INSERT_CHUNK_BYTE_LIMIT = "1";
-      const { flushAnalytics, logToolCallRequest } = await import("../../lib/services/databricks/analytics.js");
-
-      for (const toolName of ["tool-a", "tool-b", "tool-c"]) {
-        logToolCallRequest({
-          toolName,
-          requestId: null,
-          sessionId: null,
-          toolArgs: { query: "accounts" },
-          rawBody: { method: "tools/call", params: { name: toolName } },
-        });
-      }
-
-      await flushAnalytics();
-
-      expect(fetchMock).toHaveBeenCalledTimes(3);
-      for (const call of fetchMock.mock.calls) {
-        const req = recordedRequest(call as [string, RequestInit]);
-        expect(req.body.statement).toContain("mcp_tool_calls");
-        expect(req.body.parameters.filter(p => p.name.startsWith("r0_"))).toHaveLength(8);
-        expect(req.body.parameters.some(p => p.name.startsWith("r1_"))).toBe(false);
-      }
+      expect(findParam(req, "method")).toBe("initialize");
+      expect(findParam(req, "protocolVersion")).toBe("2025-03-26");
+      expect(findParam(req, "clientName")).toBe("codex");
+      expect(findParam(req, "clientVersion")).toBe("1.2.3");
+      expect(findParam(req, "capabilities")).toBe(JSON.stringify({ roots: { listChanged: true } }));
+      expect(findParam(req, "rawBody")).toBe(JSON.stringify({ method: "initialize" }));
     });
   });
 
@@ -210,7 +120,7 @@ describe("databricks analytics service", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
       const { logToolCallRequest } = await import("../../lib/services/databricks/analytics.js");
 
-      logToolCallRequest({
+      await logToolCallRequest({
         toolName: "Solana_Documentation_Search",
         requestId: "req-1",
         sessionId: "sess-1",
@@ -222,10 +132,10 @@ describe("databricks analytics service", () => {
       warnSpy.mockRestore();
     });
 
-    it("buffers and flushes a request row with tool metadata", async () => {
-      const { flushAnalytics, logToolCallRequest } = await import("../../lib/services/databricks/analytics.js");
+    it("POSTs a request row with tool metadata", async () => {
+      const { logToolCallRequest } = await import("../../lib/services/databricks/analytics.js");
 
-      logToolCallRequest({
+      await logToolCallRequest({
         toolName: "Solana_Documentation_Search",
         requestId: "req-123",
         sessionId: "session-456",
@@ -233,25 +143,20 @@ describe("databricks analytics service", () => {
         rawBody: { method: "tools/call" },
       });
 
-      expect(fetchMock).not.toHaveBeenCalled();
-
-      await flushAnalytics();
-
       expect(fetchMock).toHaveBeenCalledTimes(1);
       const req = recordedRequest(fetchMock.mock.calls[0] as [string, RequestInit]);
       expect(req.body.statement).toContain("mcp_tool_calls");
-      expect(findParam(req, "r0_row_type")).toBe("request");
-      expect(findParam(req, "r0_tool_name")).toBe("Solana_Documentation_Search");
-      expect(findParam(req, "r0_request_id")).toBe("req-123");
-      expect(findParam(req, "r0_session_id")).toBe("session-456");
-      expect(findParam(req, "r0_arguments")).toBe(JSON.stringify({ query: "accounts" }));
-      expect(findParam(req, "r0_response_text")).toBeNull();
+      expect(findParam(req, "rowType")).toBe("request");
+      expect(findParam(req, "toolName")).toBe("Solana_Documentation_Search");
+      expect(findParam(req, "requestId")).toBe("req-123");
+      expect(findParam(req, "sessionId")).toBe("session-456");
+      expect(findParam(req, "arguments")).toBe(JSON.stringify({ query: "accounts" }));
     });
 
     it("allows null requestId and sessionId", async () => {
-      const { flushAnalytics, logToolCallRequest } = await import("../../lib/services/databricks/analytics.js");
+      const { logToolCallRequest } = await import("../../lib/services/databricks/analytics.js");
 
-      logToolCallRequest({
+      await logToolCallRequest({
         toolName: "Solana_Expert__Ask_For_Help",
         requestId: null,
         sessionId: null,
@@ -259,11 +164,9 @@ describe("databricks analytics service", () => {
         rawBody: {},
       });
 
-      await flushAnalytics();
-
       const req = recordedRequest(fetchMock.mock.calls[0] as [string, RequestInit]);
-      expect(findParam(req, "r0_request_id")).toBeNull();
-      expect(findParam(req, "r0_session_id")).toBeNull();
+      expect(findParam(req, "requestId")).toBeNull();
+      expect(findParam(req, "sessionId")).toBeNull();
     });
   });
 
@@ -285,8 +188,8 @@ describe("databricks analytics service", () => {
       warnSpy.mockRestore();
     });
 
-    it("buffers a response row without awaiting Databricks", async () => {
-      const { flushAnalytics, logToolCallResponse } = await import("../../lib/services/databricks/analytics.js");
+    it("fires a response-row insert without awaiting", async () => {
+      const { logToolCallResponse } = await import("../../lib/services/databricks/analytics.js");
 
       logToolCallResponse({
         tool: "Solana_Documentation_Search",
@@ -295,26 +198,22 @@ describe("databricks analytics service", () => {
         rawBody: { tool: "Solana_Documentation_Search" },
       });
 
-      expect(fetchMock).not.toHaveBeenCalled();
-
-      await flushAnalytics();
+      await new Promise(resolve => process.nextTick(resolve));
 
       expect(fetchMock).toHaveBeenCalledTimes(1);
       const req = recordedRequest(fetchMock.mock.calls[0] as [string, RequestInit]);
       expect(req.body.statement).toContain("mcp_tool_calls");
-      expect(findParam(req, "r0_row_type")).toBe("response");
-      expect(findParam(req, "r0_tool_name")).toBe("Solana_Documentation_Search");
-      expect(findParam(req, "r0_response_text")).toBe('{"content":[]}');
-      expect(findParam(req, "r0_arguments")).toBe(JSON.stringify("find docs"));
-      expect(findParam(req, "r0_request_id")).toBeNull();
-      expect(findParam(req, "r0_session_id")).toBeNull();
+      expect(findParam(req, "rowType")).toBe("response");
+      expect(findParam(req, "toolName")).toBe("Solana_Documentation_Search");
+      expect(findParam(req, "responseText")).toBe('{"content":[]}');
+      expect(findParam(req, "arguments")).toBe(JSON.stringify("find docs"));
     });
 
-    it("requeues rows when a flush fails", async () => {
+    it("logs an error when the insert fails", async () => {
       fetchMock.mockReset();
       fetchMock.mockResolvedValue(new Response("boom", { status: 400 }));
-      const { bufferedAnalyticsRowCount, flushAnalytics, logToolCallResponse } =
-        await import("../../lib/services/databricks/analytics.js");
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const { logToolCallResponse } = await import("../../lib/services/databricks/analytics.js");
 
       logToolCallResponse({
         tool: "Solana_Documentation_Search",
@@ -323,62 +222,11 @@ describe("databricks analytics service", () => {
         rawBody: {},
       });
 
-      await expect(flushAnalytics()).rejects.toBeInstanceOf(Error);
-      expect(bufferedAnalyticsRowCount()).toBe(1);
-    });
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
 
-    it("preserves failed rows over newer rows when requeue exceeds the buffer limit", async () => {
-      process.env.DATABRICKS_ANALYTICS_MAX_BUFFERED_ROWS = "2";
-      let resolveFirstFlush: (response: Response) => void = () => undefined;
-      const firstFlushResponse = new Promise<Response>(resolve => {
-        resolveFirstFlush = resolve;
-      });
-      let failFirstFlush = true;
-      fetchMock.mockImplementation(() => {
-        if (failFirstFlush) {
-          failFirstFlush = false;
-          return firstFlushResponse;
-        }
-        return Promise.resolve(jsonResponse({ status: { state: "SUCCEEDED" } }));
-      });
-      const { flushAnalytics, logToolCallRequest } = await import("../../lib/services/databricks/analytics.js");
-
-      logToolCallRequest({
-        toolName: "failed-row",
-        requestId: null,
-        sessionId: null,
-        toolArgs: {},
-        rawBody: {},
-      });
-
-      const firstFlush = flushAnalytics();
-      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-      logToolCallRequest({
-        toolName: "newer-row",
-        requestId: null,
-        sessionId: null,
-        toolArgs: {},
-        rawBody: {},
-      });
-      logToolCallRequest({
-        toolName: "newest-row",
-        requestId: null,
-        sessionId: null,
-        toolArgs: {},
-        rawBody: {},
-      });
-
-      resolveFirstFlush(new Response("boom", { status: 400 }));
-      await expect(firstFlush).rejects.toBeInstanceOf(Error);
-      fetchMock.mockClear();
-
-      await flushAnalytics();
-
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-      const req = recordedRequest(fetchMock.mock.calls[0] as [string, RequestInit]);
-      expect(findParam(req, "r0_tool_name")).toBe("failed-row");
-      expect(findParam(req, "r1_tool_name")).toBe("newer-row");
-      expect(req.body.parameters.some(p => p.value === "newest-row")).toBe(false);
+      expect(errorSpy).toHaveBeenCalledWith("[logToolCallResponse] Error inserting tool response:", expect.any(Error));
+      errorSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Reverts commit 5a7a14fa7e1f9fb8e6b03a3d2fc596d2b8543c24 / PR #101
- Restores immediate Databricks analytics inserts for initialization and tool-call rows
- Removes the in-memory batching timer and Cloud Run shutdown flush added by that change

## Test Plan
- pnpm test
- pnpm run typecheck
- pnpm run lint

Refs: TOO-380