### PR TITLE
fix(analytics): remove s3 hour partition

### DIFF
--- a/lib/services/s3/analytics.ts
+++ b/lib/services/s3/analytics.ts
@@ -19,7 +19,6 @@ interface S3Target {
 interface FlushChunk {
   partition: {
     date: string;
-    hour: string;
   };
   rows: BufferedRow[];
 }
@@ -147,11 +146,10 @@ function requeueRows(table: AnalyticsTable, rows: BufferedRow[]): void {
   trimBuffer(table, "newest");
 }
 
-function partitionFor(timestamp: string): { date: string; hour: string } {
+function partitionFor(timestamp: string): { date: string } {
   const iso = new Date(timestamp).toISOString();
   return {
     date: iso.slice(0, 10),
-    hour: iso.slice(11, 13),
   };
 }
 
@@ -162,8 +160,7 @@ function buildFlushChunks(rows: BufferedRow[]): FlushChunk[] {
 
   for (const row of rows) {
     const partition = partitionFor(row.timestamp);
-    const partitionChanged =
-      current && (current.partition.date !== partition.date || current.partition.hour !== partition.hour);
+    const partitionChanged = current && current.partition.date !== partition.date;
     if (!current || current.rows.length >= limit || partitionChanged) {
       current = { partition, rows: [] };
       chunks.push(current);
@@ -185,7 +182,7 @@ function nextSequence(): string {
 
 function objectKey(target: S3Target, table: AnalyticsTable, chunk: FlushChunk): string {
   const fileName = `${objectTimestamp()}_${INSTANCE_ID}_${nextSequence()}.jsonl`;
-  const key = `${table}/dt=${chunk.partition.date}/hour=${chunk.partition.hour}/${fileName}`;
+  const key = `${table}/dt=${chunk.partition.date}/${fileName}`;
   return target.prefix ? `${target.prefix}/${key}` : key;
 }
 

--- a/tests/unit/s3.analytics.test.ts
+++ b/tests/unit/s3.analytics.test.ts
@@ -102,7 +102,7 @@ describe("S3 analytics service", () => {
     const input = putObjectInput();
     expect(input.Bucket).toBe("example-analytics-bucket");
     expect(input.Key).toMatch(
-      /^mcp_analytics\/mcp_initializations\/dt=2026-05-27\/hour=14\/2026-05-27T14-31-22-123Z_[a-f0-9]{8}_000001\.jsonl$/,
+      /^mcp_analytics\/mcp_initializations\/dt=2026-05-27\/2026-05-27T14-31-22-123Z_[a-f0-9]{8}_000001\.jsonl$/,
     );
     expect(input.ContentType).toBe("application/x-ndjson");
     expect(jsonlRows(input)).toEqual([


### PR DESCRIPTION
## Summary
- Remove the hour-level partition from analytics S3 object keys.
- Keep analytics objects grouped by table and dt only.
- Update S3 analytics unit coverage for the new key layout.

## Test Plan
- pnpm exec vitest run tests/unit/s3.analytics.test.ts
- pnpm typecheck

## Breaking Changes
- Analytics S3 object keys no longer include hour=<HH> directories.