### PR TITLE
feat(monitoring): add weekly traffic alert

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -25,6 +25,8 @@ variables:
   bundle_root:
     description: Workspace path prefix where the bundle artifacts live.
     default: /Workspace/.bundle/solana-mcp/${bundle.target}
+  alert_email:
+    description: Subscriber email for the weekly traffic alert.
 
 targets:
   prod:
@@ -65,3 +67,35 @@ resources:
       # dashboards/solana_mcp.example.lvdash.json for the template.
       file_path: ./dashboards/solana_mcp.lvdash.json
       warehouse_id: ${var.warehouse_id}
+
+  alerts:
+    weekly_traffic:
+      display_name: Solana MCP weekly traffic
+      warehouse_id: ${var.warehouse_id}
+      query_text: |
+        SELECT tool_name, count(*) AS calls
+        FROM ${var.catalog}.${var.schema}.mcp_tool_calls
+        WHERE row_type = 'response'
+          AND timestamp >= current_timestamp() - INTERVAL 7 DAYS
+        GROUP BY tool_name
+        ORDER BY calls DESC
+      custom_summary: "Solana MCP tool calls, last 7 days"
+      custom_description: |
+        <h3>Solana MCP traffic, last 7 days</h3>
+        {{QUERY_RESULT_TABLE}}
+      evaluation:
+        comparison_operator: GREATER_THAN_OR_EQUAL
+        empty_result_state: TRIGGERED
+        source:
+          name: calls
+        threshold:
+          value:
+            double_value: 0
+        notification:
+          retrigger_seconds: 1
+          subscriptions:
+            - user_email: ${var.alert_email}
+      schedule:
+        quartz_cron_schedule: "0 0 9 ? * MON"
+        timezone_id: UTC
+        pause_status: UNPAUSED

--- a/databricks.yml
+++ b/databricks.yml
@@ -92,7 +92,7 @@ resources:
           value:
             double_value: 0
         notification:
-          retrigger_seconds: 1
+          retrigger_seconds: 518400
           subscriptions:
             - user_email: ${var.alert_email}
       schedule:


### PR DESCRIPTION
## Summary
- Add Alert V2 bundle resource `weekly_traffic` to `databricks.yml`.
- Emails a per-tool MCP call breakdown (last 7 days) every Monday 09:00 UTC.
- Always fires: `retrigger_seconds: 1` re-notifies each weekly run; `empty_result_state: TRIGGERED` covers zero-traffic weeks.
- Body renders an HTML table via `{{QUERY_RESULT_TABLE}}` (email destination, ≤100 rows).

## Test Plan
- Query validated against warehouse `bebc0b84d34202ba` on `prod.solana_mcp.mcp_tool_calls` — returns per-tool rows (list_sections 668, program_autofixer 604, …).
- `databricks bundle validate` passes config/schema checks (no alert errors).

## Notes
- **Not auto-deployed by CI** — neither `ci.yml` nor `deploy-cloudrun.yml` runs `databricks bundle deploy`. Activate manually post-merge: `databricks bundle deploy` (requires gitignored `prod.yml`).