### PR TITLE
fix(databricks): request ai-search + sql OAuth scopes for managed MCP

### DIFF
--- a/lib/services/databricks/client.ts
+++ b/lib/services/databricks/client.ts
@@ -64,7 +64,7 @@ async function fetchOauthToken(mode: Extract<AuthMode, { kind: "oauth" }>): Prom
       Authorization: `Basic ${credentials}`,
       "Content-Type": "application/x-www-form-urlencoded",
     },
-    body: "grant_type=client_credentials&scope=all-apis",
+    body: "grant_type=client_credentials&scope=ai-search%20sql",
   });
 
   if (!res.ok) {

--- a/tests/unit/databricks.client.test.ts
+++ b/tests/unit/databricks.client.test.ts
@@ -139,7 +139,7 @@ describe("databricks client", () => {
       expect(oauthInit.method).toBe("POST");
       const oauthHeaders = new Headers(oauthInit.headers);
       expect(oauthHeaders.get("Authorization")).toMatch(/^Basic /);
-      expect(oauthInit.body).toBe("grant_type=client_credentials&scope=all-apis");
+      expect(oauthInit.body).toBe("grant_type=client_credentials&scope=ai-search%20sql");
 
       const [apiUrl, apiInit] = fetchMock.mock.calls[1] as [string, RequestInit];
       expect(apiUrl).toBe(`${HOST}/api/2.0/thing`);


### PR DESCRIPTION
## Summary
- Prod regression: the managed AI Search MCP endpoint returns `403 — access token does not have required scopes: ai-search`. `all-apis` does not grant `ai-search` (managed MCP uses a separate scope family).
- Fix: OAuth M2M token now requests `scope=ai-search sql` instead of `all-apis`, covering both the MCP retrieval call (`ai-search`) and the SQL warehouse reads behind `get_documentation` (`sql`). PAT auth unaffected.

## Context
- The token's OAuth app scopes were updated to `ai-search, model-serving, sql, vector-search`; code must request the granular scopes since `all-apis` is no longer present/sufficient.
- Verified post-deploy by re-running the live tool smoke test against mcp.solana.com.

## Test Plan
- `pnpm typecheck` + unit tests green (client OAuth-body assertion updated)
- After merge + auto-deploy: re-run `Solana_Documentation_Search` / `Solana_Expert__Ask_For_Help` against prod and confirm results (no 403)