### PR TITLE
feat(databricks): oversample managed rerank pool (k*3, capped at 50)

### DIFF
--- a/lib/services/databricks/vectorSearch.ts
+++ b/lib/services/databricks/vectorSearch.ts
@@ -25,6 +25,9 @@ const RERANK_COLUMN = "content";
 const DEFAULT_K = 20;
 const MAX_K = 50;
 const OVERSAMPLE_MULTIPLIER = 3;
+// Endpoint's hard cap for reranked queries: num_results above this errors.
+// Keep MAX_K <= RERANK_MAX_RESULTS, or large-k callers are silently clamped
+// to fewer results than requested.
 const RERANK_MAX_RESULTS = 50;
 
 function resolveK(k?: number): number {

--- a/lib/services/databricks/vectorSearch.ts
+++ b/lib/services/databricks/vectorSearch.ts
@@ -24,6 +24,8 @@ const RERANK_COLUMN = "content";
 
 const DEFAULT_K = 20;
 const MAX_K = 50;
+const OVERSAMPLE_MULTIPLIER = 3;
+const RERANK_MAX_RESULTS = 50;
 
 function resolveK(k?: number): number {
   if (typeof k === "number" && Number.isInteger(k) && k > 0) return Math.min(k, MAX_K);
@@ -69,7 +71,7 @@ export async function searchDocs(query: string, k?: number): Promise<DocChunk[]>
     target.tool,
     { query },
     {
-      num_results: String(topK),
+      num_results: String(Math.min(topK * OVERSAMPLE_MULTIPLIER, RERANK_MAX_RESULTS)),
       columns: REQUESTED_COLUMNS.join(","),
       columns_to_rerank: RERANK_COLUMN,
       include_score: "true",

--- a/tests/unit/databricks.vectorSearch.test.ts
+++ b/tests/unit/databricks.vectorSearch.test.ts
@@ -100,7 +100,7 @@ describe("databricks vectorSearch (managed AI Search MCP)", () => {
     warnSpy.mockRestore();
   });
 
-  it("calls the ai-search MCP tool with query + _meta (num_results = k, no oversample)", async () => {
+  it("calls the ai-search MCP tool with query + _meta, oversampling num_results (k*3)", async () => {
     fetchMock.mockResolvedValueOnce(mcpResponse([]));
 
     const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");
@@ -116,7 +116,7 @@ describe("databricks vectorSearch (managed AI Search MCP)", () => {
     expect(body.method).toBe("tools/call");
     expect(body.params.name).toBe(TOOL);
     expect(body.params.arguments.query).toBe("how to derive a PDA");
-    expect(body.params._meta.num_results).toBe("5");
+    expect(body.params._meta.num_results).toBe("15");
     expect(body.params._meta.columns).toBe("id,url,title,source_id,content");
     expect(body.params._meta.columns_to_rerank).toBe("content");
     expect(body.params._meta.include_score).toBe("true");
@@ -232,12 +232,12 @@ describe("databricks vectorSearch (managed AI Search MCP)", () => {
     expect(chunks.map(c => c.id)).toEqual(["id-1", "id-2"]);
   });
 
-  it("defaults k to 20 (num_results=20) when no arg or env", async () => {
+  it("defaults k to 20 and clamps oversampled num_results to the rerank cap of 50", async () => {
     fetchMock.mockResolvedValueOnce(mcpResponse([]));
     const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");
     await searchDocs("hello");
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect((JSON.parse(init.body as string) as ToolCallBody).params._meta.num_results).toBe("20");
+    expect((JSON.parse(init.body as string) as ToolCallBody).params._meta.num_results).toBe("50");
   });
 
   it("reads DATABRICKS_VS_K env when arg omitted", async () => {
@@ -246,7 +246,7 @@ describe("databricks vectorSearch (managed AI Search MCP)", () => {
     const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");
     await searchDocs("hello");
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect((JSON.parse(init.body as string) as ToolCallBody).params._meta.num_results).toBe("12");
+    expect((JSON.parse(init.body as string) as ToolCallBody).params._meta.num_results).toBe("36");
   });
 
   it("caps k at 50 regardless of arg or env", async () => {

--- a/tests/unit/databricks.vectorSearch.test.ts
+++ b/tests/unit/databricks.vectorSearch.test.ts
@@ -232,6 +232,21 @@ describe("databricks vectorSearch (managed AI Search MCP)", () => {
     expect(chunks.map(c => c.id)).toEqual(["id-1", "id-2"]);
   });
 
+  it("returns fewer than k when dedupe collapses the oversampled pool", async () => {
+    fetchMock.mockResolvedValueOnce(
+      mcpResponse([
+        { id: "a", url: "https://x/1", title: "T", source_id: "s", content: "c1", score: 0.9 },
+        { id: "b", url: "https://x/1", title: "T", source_id: "s", content: "c2", score: 0.8 },
+        { id: "c", url: "https://x/1", title: "T", source_id: "s", content: "c3", score: 0.7 },
+        { id: "d", url: "https://x/2", title: "U", source_id: "s", content: "c4", score: 0.6 },
+      ]),
+    );
+
+    const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");
+    const chunks = await searchDocs("q", 20);
+    expect(chunks.map(c => c.id)).toEqual(["a", "d"]);
+  });
+
   it("defaults k to 20 and clamps oversampled num_results to the rerank cap of 50", async () => {
     fetchMock.mockResolvedValueOnce(mcpResponse([]));
     const { searchDocs } = await import("../../lib/services/databricks/vectorSearch.js");


### PR DESCRIPTION
## Summary
- Request `num_results = min(k * 3, 50)` from the managed AI Search MCP, then dedupe + slice to `k`. Gives the server-side reranker a deeper candidate pool to order, improving ranking quality at no token cost.
- The **50 ceiling is a hard endpoint limit** for reranked queries — `num_results > 50` with `columns_to_rerank` returns `INVALID_PARAMETER_VALUE`. The clamp is mandatory; without it, the default K=20 path (→60) would error on every query.

## Why
After dropping the Claude-Haiku LLM reranker (#116), an 8-query LLM-judged nDCG@8 eval showed the native reranker trailing:
- old (Haiku) ≈ 0.91, new@k=8 ≈ 0.74
- Oversampling the rerank pool recovers most of the gap: new@24 ≈ 0.82, **free** (no LLM tokens).

Measured downsides: latency flat to n=50 (~2s, no scaling); payload ~2KB/doc (default 20→50 ≈ 2.3× bytes, kept docs sliced to k). Quality still slightly below Haiku, but no token cost.

## Test Plan
- `pnpm typecheck` + 207 unit tests green (num_results assertions updated: k=5→15, default→50, VS_K=12→36, cap k=50→50)
- Eval methodology: single LLM judge, 8 queries — directional, not authoritative

## Notes
- Quality gain was measured at k=8; prod default is k=20 (already a deeper pool), so real-world lift may be smaller.