### PR TITLE
feat(sources): add Surfpool docs (solana.com/docs/tools/surfpool)

### DIFF
--- a/ingestion/sources.yaml
+++ b/ingestion/sources.yaml
@@ -97,6 +97,17 @@ sources:
       - https://www.solana-program.com
       - https://www.solana-program.com/docs
 
+  - id: surfpool-docs
+    name: Surfpool Docs (solana.com/docs/tools/surfpool)
+    kind: web
+    enabled: true
+    sections: [testing, tooling]
+    use_cases: "Surfpool local validator, solana-test-validator replacement, surfnet RPC cheatcodes, mainnet account fetching on-demand, surfpool CLI/TUI, Surfpool SDK, txtx Infrastructure as Code deployments"
+    primary_url: https://solana.com/docs/tools/surfpool
+    start_urls:
+      - https://solana.com/docs/tools/surfpool
+    url_include: [/docs/tools/surfpool]
+
   - id: solana-mobile-docs
     name: Solana Mobile Docs
     kind: web


### PR DESCRIPTION
## What

Adds a dedicated `surfpool-docs` web source for https://solana.com/docs/tools/surfpool.

```yaml
- id: surfpool-docs
  name: Surfpool Docs (solana.com/docs/tools/surfpool)
  kind: web
  enabled: true
  sections: [testing, tooling]
  use_cases: "Surfpool local validator, solana-test-validator replacement, surfnet RPC cheatcodes, mainnet account fetching on-demand, surfpool CLI/TUI, Surfpool SDK, txtx Infrastructure as Code deployments"
  primary_url: https://solana.com/docs/tools/surfpool
  start_urls:
    - https://solana.com/docs/tools/surfpool
  url_include: [/docs/tools/surfpool]
```

## Why

Surfpool is currently only represented by `gh-surfpool`, which ingests the repo READMEs plus Rust source. That misses the prose documentation, which is where the actual usage guidance lives:

- `toolchain/getting-started`, `toolchain/cli`, `toolchain/tui`
- `sdk/overview`
- `rpc/overview`, `rpc/cheatcodes`, `rpc/websockets`
- `iac/getting-started`, `iac/language`, `iac/svm/overview`

Tagging it `[testing, tooling]` puts it alongside `gh-surfpool`, `gh-mollusk`, and `gh-litesvm` in `list_sections`, so agents asking "how do I run a local validator with mainnet accounts" get routed here.

## Notes on scoping

`url_include: [/docs/tools/surfpool]` pins the BFS-lite crawl to the surfpool subtree. Without it, `crawl_web`'s link-following would walk out into all of `solana.com/docs`, which `solana-docs` already covers. Same pattern as the existing `url_include` filters on `quicknode-docs` / `alchemy-docs` / `wormhole-docs`.

Section tags are both already in the closed taxonomy in `lib/sources.types.ts` — no new tags introduced.

## Testing

- `pnpm gen:sources` — passes structural validation, 160 → 161 sources
- `pnpm test:integration` — 219 tests / 17 files pass (includes the `freezeSources` unknown-tag runtime check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)