### PR TITLE
feat(sources): stop promoting gill, add solana-dev-skill

### DIFF
--- a/ingestion/sources.yaml
+++ b/ingestion/sources.yaml
@@ -77,11 +77,11 @@ sources:
       - https://www.solanakit.com
 
   - id: solana-gill-docs
-    name: Solana > Gill Docs
+    name: Solana > Gill Docs (legacy — prefer @solana/kit plugins)
     kind: web
     enabled: true
     sections: [clients]
-    use_cases: "Gill SDK, ergonomic Solana client wrapper around kit, transaction helpers, simplified RPC"
+    use_cases: "Do not use for new code — prefer @solana/kit plugin clients (solana-kit-docs, gh-solana-dev-skill). Retrieve only to recognize Gill APIs in an existing codebase and translate them to @solana/kit"
     primary_url: https://www.gillsdk.com/docs
     start_urls:
       - https://www.gillsdk.com/docs
@@ -298,14 +298,23 @@ sources:
     primary_url: https://github.com/solana-developers/program-examples
     github: { owner: solana-developers, repo: program-examples, include_readmes: false, include_source_code: true }
 
+  - id: gh-solana-dev-skill
+    name: GitHub solana-foundation/solana-dev-skill
+    kind: github
+    enabled: true
+    sections: [clients, programs, testing]
+    use_cases: "Opinionated Solana development playbook and recommended default stack: @solana/kit v7 plugin clients (createClient + .use()), kit signer/RPC/wallet plugins, @solana/react wallet connection, Codama client generation, Anchor 1.1.x and Pinocchio programs, Surfpool/LiteSVM/Mollusk testing, security checklists, Token-2022 confidential transfers, version compatibility matrix, common error triage, web3.js v1 migration routing"
+    primary_url: https://github.com/solana-foundation/solana-dev-skill
+    github: { owner: solana-foundation, repo: solana-dev-skill, include_readmes: true, include_source_code: false }
+
   - id: gh-gill
-    name: GitHub gillsdk/gill
+    name: GitHub gillsdk/gill (legacy — prefer @solana/kit plugins)
     kind: github
     enabled: true
     sections: [clients]
-    use_cases: "Gill SDK source, ergonomic wrapper around @solana/kit, transaction helpers"
+    use_cases: "Do not use for new code — prefer @solana/kit plugin clients (solana-kit-docs, gh-solana-dev-skill). Retrieve only to recognize Gill APIs in an existing codebase and translate them to @solana/kit"
     primary_url: https://github.com/gillsdk/gill
-    github: { owner: gillsdk, repo: gill, include_readmes: true, include_source_code: true }
+    github: { owner: gillsdk, repo: gill, include_readmes: true, include_source_code: false }
 
   - id: gh-wallet-adapter
     name: GitHub anza-xyz/wallet-adapter

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -19,6 +19,7 @@ Routing:
 - Canonical spec for a library / program / framework → list_sections, then get_documentation.
 - Narrow question or error message → Solana_Documentation_Search or Solana_Expert__Ask_For_Help.
 - Compare or survey an ecosystem area (all DeFi, all wallets) → get_documentation with a section taxonomy id.
+- Client-side TypeScript → @solana/kit plugin clients (solana-kit-docs, gh-solana-dev-skill). Gill is not recommended for new code; when a codebase already uses it, translate to @solana/kit rather than extending it.
 - Generating or editing Solana program Rust → run program_autofixer before returning the code. Re-run after each fix pass.
 - When in doubt, list_sections first; use_cases keywords guide selection.`;
 


### PR DESCRIPTION
## What

Gill is no longer encouraged for new work — `@solana/kit` plugin clients are the recommended path. This removes gill from every place the server promotes an SDK, while keeping just enough indexed to help someone already on it.

**Gill de-promoted** (`solana-gill-docs`, `gh-gill`) — both stay enabled:
- `use_cases` rewritten to be imperative: *do not use for new code; retrieve only to recognize gill APIs in an existing codebase and translate them to `@solana/kit`*.
- `(legacy — prefer @solana/kit plugins)` added to both names, which is what `list_sections` renders as the title.
- `include_source_code: false` on `gh-gill`, so future runs stop ingesting 251 TS files (~563 KB) of gill idiom. The 48 md/mdx docs stay.

**Stance added to `SERVER_INSTRUCTIONS`.** `use_cases` only surface if the agent calls `list_sections` — `Solana_Documentation_Search` and `Solana_Expert__Ask_For_Help` bypass them entirely. The new Routing line is the only lever that fires on every request.

**`gh-solana-dev-skill` added** — `solana-foundation/solana-dev-skill`, tagged `[clients, programs, testing]`. Kit-first playbook: `createClient().use()` plugin clients, `@solana/kit-plugin-wallet` + `@solana/react`, Codama codegen, Anchor 1.1.x vs Pinocchio, Surfpool/LiteSVM/Mollusk. Also carries a version compatibility matrix and toolchain/GLIBC error triage, which nothing else in the corpus has. Markdown-only repo, so `include_source_code: false` — the crawler ingests `.md`/`.mdx` regardless of that flag.

## Known gap: already-indexed gill source is not evicted

Flagged by Greptile and confirmed. The MERGE at `ingestion/crawl_and_index.py:537` is `whenMatchedUpdate` + `whenNotMatchedInsertAll()` with no delete clause, and chunk ids are `sha256(source_id|url|heading_path|content_hash)`. Gill's existing `.ts` rows are therefore never matched by the new source frame, never deleted, and survive `idx.sync()`.

So `include_source_code: false` prevents re-ingestion but does **not** remove gill source already in the index — it stays searchable and keeps competing in the RAG pool. The instruction-level and `use_cases` changes in this PR still take effect immediately; only the index-footprint reduction is deferred.

This is a pre-existing gap, not introduced here: no source in the corpus can currently be shrunk or disabled and have its chunks pruned. Fixing it needs a per-source-scoped prune (delete rows whose `source_id` was crawled successfully this run but whose `id` is absent from the new frame). It has to be scoped rather than a blanket `whenNotMatchedBySourceDelete()`, because `crawl_github` returns `[]` on clone failure (line 405) — an unscoped delete would let a transient network error wipe a healthy source. Tracking separately since it changes production delete semantics.

## Why keep gill indexed at all

Disabling it is counterproductive. Training data is saturated with gill, so an agent that retrieves nothing answers from priors and writes *more* gill. Keeping the docs indexed and framed as migration-only is what lets us redirect someone instead of being absent from the conversation.

Note that no gill → kit API mapping exists anywhere in the corpus, so agents will improvise the translation. Accepted for now given gill's user count.

## Testing

All five CI jobs run locally before push: `format` (no drift), `lint`, `typecheck` (163 type tests), `test:integration` (218), `test:e2e` (1). 162 sources generated.

No version bump — sources-only change, consistent with #127.