### PR TITLE
feat(sources): add Anchor v2 docs

### DIFF
--- a/ingestion/sources.yaml
+++ b/ingestion/sources.yaml
@@ -66,6 +66,16 @@ sources:
     start_urls:
       - https://www.anchor-lang.com/docs
 
+  - id: anchor-v2-docs
+    name: Solana > Anchor v2 Docs
+    kind: web
+    enabled: true
+    sections: [frameworks, programs]
+    use_cases: "Anchor v2 alpha framework, v1 to v2 migration, smaller binaries and CU optimization, account constraints, PDAs, IDL, Rust and TypeScript clients, LiteSVM testing, secure defaults"
+    primary_url: https://v2.anchor-lang.com/docs
+    start_urls:
+      - https://v2.anchor-lang.com/docs
+
   - id: solana-kit-docs
     name: Solana Kit Docs
     kind: web


### PR DESCRIPTION
## What

Adds `anchor-v2-docs` to the ingestion corpus.

- **id**: `anchor-v2-docs`
- **kind**: web (`start_urls: https://v2.anchor-lang.com/docs`; site publishes no sitemap, root 307s to /docs)
- **sections**: frameworks, programs (same as `anchor-docs`)

## Why

Anchor v2 alpha docs live on a separate subdomain (`v2.anchor-lang.com`) not covered by the existing `anchor-docs` source (`www.anchor-lang.com/docs`, v1). Covers v2 migration, new account model, constraints, LiteSVM testing, CU/binary-size optimizations.

## Validation

`pnpm gen:sources` (163 sources) and `pnpm typecheck` pass.

## After merge

Databricks picks this up on the next `just deploy`; the daily 09:00 UTC crawl then ingests it. Cloud Run side regenerates automatically on deploy.