### PR TITLE
fix(sources): correct routing keywords for v1 transactions (SIMD-0385)

### DIFF
--- a/ingestion/sources.yaml
+++ b/ingestion/sources.yaml
@@ -50,11 +50,12 @@ sources:
     kind: web
     enabled: true
     sections: [core, clients, programs]
-    use_cases: "Solana fundamentals, accounts model, transactions, fees, rent, PDAs, sysvars, RPC API, web3.js basics, intro tutorials"
+    use_cases: "Solana fundamentals, accounts model, transactions, fees, rent, PDAs, sysvars, RPC API, web3.js basics, intro tutorials, network upgrades, feature gate activation status, larger transaction sizes"
     primary_url: https://solana.com/docs
     start_urls:
       - https://solana.com/docs
-    url_include: [/docs, /developers]
+      - https://solana.com/upgrades
+    url_include: [/docs, /developers, /upgrades]
 
   - id: anchor-docs
     name: Solana > Anchor Docs
@@ -241,7 +242,7 @@ sources:
     kind: github
     enabled: true
     sections: [clients]
-    use_cases: "Legacy @solana/web3.js v1.x SDK, Connection class, Transaction, PublicKey, prefer kit for new code, cannot read v1 (SIMD-0385) transactions"
+    use_cases: "Legacy @solana/web3.js v1.x SDK, Connection class, Transaction, PublicKey, prefer kit for new code"
     primary_url: https://github.com/solana-foundation/solana-web3.js
     github: { owner: solana-foundation, repo: solana-web3.js, include_readmes: true, include_source_code: true }
 

--- a/ingestion/sources.yaml
+++ b/ingestion/sources.yaml
@@ -241,7 +241,7 @@ sources:
     kind: github
     enabled: true
     sections: [clients]
-    use_cases: "Legacy @solana/web3.js v1.x SDK, Connection class, Transaction, PublicKey, prefer kit for new code"
+    use_cases: "Legacy @solana/web3.js v1.x SDK, Connection class, Transaction, PublicKey, prefer kit for new code, cannot read v1 (SIMD-0385) transactions"
     primary_url: https://github.com/solana-foundation/solana-web3.js
     github: { owner: solana-foundation, repo: solana-web3.js, include_readmes: true, include_source_code: true }
 
@@ -295,7 +295,7 @@ sources:
     kind: github
     enabled: true
     sections: [core]
-    use_cases: "SIMD Solana Improvement Documents, protocol changes, runtime upgrades, validator protocol specs"
+    use_cases: "SIMD Solana Improvement Documents, protocol changes, runtime upgrades, validator protocol specs, v1 transaction format (SIMD-0385), larger transactions (SIMD-0296)"
     primary_url: https://github.com/solana-foundation/solana-improvement-documents
     github: { owner: solana-foundation, repo: solana-improvement-documents, include_readmes: false, include_source_code: true }
 
@@ -413,7 +413,7 @@ sources:
     kind: github
     enabled: true
     sections: [core, programs]
-    use_cases: "Address Lookup Tables (ALT), versioned transactions, fitting more accounts per tx, lookup table extension"
+    use_cases: "Address Lookup Tables (ALT), v0 versioned transactions, lookup table extension, v0-only (v1 transactions fit 64 inline addresses without ALTs)"
     primary_url: https://github.com/solana-program/address-lookup-table
     github: { owner: solana-program, repo: address-lookup-table, include_readmes: true, include_source_code: true }
 


### PR DESCRIPTION
## Summary
- Reword the Address Lookup Table source: ALTs are v0-only; v1 transactions fit 64 inline addresses without ALTs, so 'fitting more accounts per tx' no longer routes there unconditionally
- Route v1 transaction format (SIMD-0385) and larger transaction (SIMD-0296) questions to the SIMD source, which already indexes both proposals
- Add `solana.com/upgrades` to the `solana-docs` crawl scope (start URL + `url_include`); the canonical rollout and feature-gate activation pages, including larger transaction sizes, were previously never indexed

## Test Plan
- `node scripts/build-sources.mjs` regenerates cleanly (163 sources)
- `just test` 218/218 pass
- prettier clean on the changed file
- Verified `https://solana.com/upgrades` and `/upgrades/larger-transaction-sizes` both return 200 and are reachable by the BFS crawler once `/upgrades` is in `url_include`