### PR TITLE
fix(autofixer): credit arbitrary-cpi verification outside the invoking fn

### DIFF
--- a/lib/tools/programAutofixer/handler.ts
+++ b/lib/tools/programAutofixer/handler.ts
@@ -254,6 +254,7 @@ export async function runProgramAutofixer({
     filename,
     framework: resolvedFramework,
     output,
+    tree,
     tryFromBodies: findTryFromBodies(tree),
     anchor: collectAnchorContext(tree),
   };

--- a/lib/tools/programAutofixer/types.ts
+++ b/lib/tools/programAutofixer/types.ts
@@ -32,6 +32,8 @@ export interface VisitorContext {
   filename: string;
   framework: Framework;
   output: AutofixerOutput;
+  /** Parsed tree for the whole input, for checks that must look outside the enclosing function. */
+  tree: Tree;
   /** Cached once per run by the driver. Populated before any enter handler fires. */
   tryFromBodies: TryFromBody[];
   /** Cached once per run by the driver. Anchor-specific structures (Accounts derives + #[program] mod). */

--- a/lib/tools/programAutofixer/visitors/_helpers.ts
+++ b/lib/tools/programAutofixer/visitors/_helpers.ts
@@ -109,6 +109,23 @@ function collectIdentifiers(node: Node, out: string[]): void {
   }
 }
 
+const PROGRAM_VERIFY_NAME_RE = /^(verify|check|assert)_.*program/;
+const EXTRA_PROGRAM_VERIFY_NAMES = new Set(["check_id", "check_program_id", "assert_program_id", "verify_program"]);
+
+export function fileContainsProgramVerifyFor(root: Node, account: string): boolean {
+  let found = false;
+  walk(root, n => {
+    if (found) return "skip";
+    if (n.type !== "call_expression") return;
+    const fn = n.childForFieldName("function");
+    const name = fn ? getCallName(fn) : null;
+    if (!name) return;
+    if (!PROGRAM_VERIFY_NAME_RE.test(name) && !EXTRA_PROGRAM_VERIFY_NAMES.has(name)) return;
+    if (getCallArgs(n).some(a => rootIdentifierOf(a) === account)) found = true;
+  });
+  return found;
+}
+
 export function isSignerName(name: string): boolean {
   return SIGNER_NAMES.has(name.toLowerCase());
 }

--- a/lib/tools/programAutofixer/visitors/arbitrary-cpi.ts
+++ b/lib/tools/programAutofixer/visitors/arbitrary-cpi.ts
@@ -1,4 +1,4 @@
-import type { Node } from "web-tree-sitter";
+import type { Node, Tree } from "web-tree-sitter";
 import type { Visitor } from "../types.js";
 import { formatLocation } from "../types.js";
 import { getCallName, walk } from "../walk.js";
@@ -6,7 +6,9 @@ import {
   KEY_MARKERS,
   bodyContainsRejectingCheckFor,
   bodyContainsVerifyFor,
+  fileContainsProgramVerifyFor,
   findEnclosingFunctionBody,
+  findFunctionByName,
   getCallArgs,
   isProgramAccountName,
   rootIdentifierOf,
@@ -140,14 +142,43 @@ function invokeUsesVerifiedProgram(call: Node, verifiedPrograms: ReadonlySet<str
   return false;
 }
 
-function programAccountKeyChecked(scope: Node, invoke: Node): boolean {
+function programAccountVerified(scope: Node, invoke: Node): boolean {
   const roots = new Set<string>();
   for (const arg of getCallArgs(invoke)) {
     for (const root of collectRootIdentifiers(arg)) roots.add(root);
   }
-  for (const root of programShapedRoots(roots)) {
-    if (bodyContainsVerifyFor(scope, CHECK_ID_FNS, root)) return true;
-    if (bodyContainsRejectingCheckFor(scope, root, KEY_MARKERS)) return true;
+  const programRoots = programShapedRoots(roots);
+  if (programRoots.size === 0) return false;
+  for (const root of programRoots) {
+    const verified =
+      bodyContainsVerifyFor(scope, CHECK_ID_FNS, root) ||
+      bodyContainsRejectingCheckFor(scope, root, KEY_MARKERS) ||
+      fileContainsProgramVerifyFor(scope, root);
+    if (!verified) return false;
+  }
+  return true;
+}
+
+function isLocalInstructionBuilder(tree: Tree, name: string): boolean {
+  const fn = findFunctionByName(tree, name);
+  if (!fn) return false;
+  const returnType = fn.childForFieldName("return_type");
+  if (!returnType?.text.includes("Instruction")) return false;
+  const body = fn.childForFieldName("body");
+  return !!body && invokeUsesHardcodedProgramId(body);
+}
+
+function builtByLocalHardcodedBuilder(tree: Tree, candidates: Node[]): boolean {
+  for (const candidate of candidates) {
+    let hardcoded = false;
+    walk(candidate, n => {
+      if (hardcoded) return "skip";
+      if (n.type !== "call_expression") return;
+      const fn = n.childForFieldName("function");
+      const name = fn ? getCallName(fn) : null;
+      if (name && isLocalInstructionBuilder(tree, name)) hardcoded = true;
+    });
+    if (hardcoded) return true;
   }
   return false;
 }
@@ -157,8 +188,8 @@ export const arbitraryCpi: Visitor = {
   severity: "critical",
   appliesTo: ["pinocchio"],
   falsePositiveWhen: [
-    "program id verified in the accounts struct try_from or a helper outside this fn",
-    "instruction built by project-local builder hardcoding the id internally",
+    "program id verified in a helper in another file, outside the submitted text",
+    "instruction built by a project-local builder in another file, or one whose return type is not Instruction",
     "program binding name not program-shaped so verification unattributed",
     "instruction flows through match/closure/struct-field bindings untraceable to ::ID",
   ],
@@ -177,8 +208,9 @@ export const arbitraryCpi: Visitor = {
       const candidates = candidateInstructionExprs(scope, node);
       if (candidates.some(invokeUsesHardcodedProgramId)) return;
       if (candidates.some(isTrustedBuilderExpr)) return;
+      if (builtByLocalHardcodedBuilder(ctx.tree, candidates)) return;
       if (invokeUsesVerifiedProgram(node, verifiedProgramsBefore(scope, node.startIndex))) return;
-      if (programAccountKeyChecked(scope, node)) return;
+      if (programAccountVerified(ctx.tree.rootNode, node)) return;
       ctx.output.issues.push({
         severity: "critical",
         rule: "arbitrary-cpi",

--- a/lib/tools/programAutofixer/visitors/arbitrary-cpi.ts
+++ b/lib/tools/programAutofixer/visitors/arbitrary-cpi.ts
@@ -1,14 +1,13 @@
 import type { Node, Tree } from "web-tree-sitter";
 import type { Visitor } from "../types.js";
 import { formatLocation } from "../types.js";
-import { getCallName, walk } from "../walk.js";
+import { findAll, getCallName, walk } from "../walk.js";
 import {
   KEY_MARKERS,
   bodyContainsRejectingCheckFor,
   bodyContainsVerifyFor,
   fileContainsProgramVerifyFor,
   findEnclosingFunctionBody,
-  findFunctionByName,
   getCallArgs,
   isProgramAccountName,
   rootIdentifierOf,
@@ -160,8 +159,13 @@ function programAccountVerified(scope: Node, invoke: Node): boolean {
 }
 
 function isLocalInstructionBuilder(tree: Tree, name: string): boolean {
-  const fn = findFunctionByName(tree, name);
-  if (!fn) return false;
+  const matches = findAll(tree.rootNode, n => {
+    if (n.type !== "function_item") return false;
+    return n.childForFieldName("name")?.text === name;
+  });
+  // A duplicated name (concatenated modules) makes the call unattributable, so don't trust it.
+  if (matches.length !== 1) return false;
+  const fn = matches[0];
   const returnType = fn.childForFieldName("return_type");
   if (!returnType?.text.includes("Instruction")) return false;
   const body = fn.childForFieldName("body");
@@ -174,9 +178,11 @@ function builtByLocalHardcodedBuilder(tree: Tree, candidates: Node[]): boolean {
     walk(candidate, n => {
       if (hardcoded) return "skip";
       if (n.type !== "call_expression") return;
+      // Bare calls only: a qualified path or method call can't be attributed to a local
+      // function by name alone.
       const fn = n.childForFieldName("function");
-      const name = fn ? getCallName(fn) : null;
-      if (name && isLocalInstructionBuilder(tree, name)) hardcoded = true;
+      if (fn?.type !== "identifier") return;
+      if (isLocalInstructionBuilder(tree, fn.text)) hardcoded = true;
     });
     if (hardcoded) return true;
   }
@@ -189,7 +195,7 @@ export const arbitraryCpi: Visitor = {
   appliesTo: ["pinocchio"],
   falsePositiveWhen: [
     "program id verified in a helper in another file, outside the submitted text",
-    "instruction built by a project-local builder in another file, or one whose return type is not Instruction",
+    "instruction built by a project-local builder in another file, called via a qualified path or method, sharing its name with another function, or not returning Instruction",
     "program binding name not program-shaped so verification unattributed",
     "instruction flows through match/closure/struct-field bindings untraceable to ::ID",
   ],

--- a/lib/tools/programAutofixer/visitors/arbitrary-cpi.ts
+++ b/lib/tools/programAutofixer/visitors/arbitrary-cpi.ts
@@ -158,7 +158,44 @@ function programAccountVerified(scope: Node, invoke: Node): boolean {
   return true;
 }
 
-function isLocalInstructionBuilder(tree: Tree, name: string): boolean {
+function buildsInstructionWithHardcodedId(body: Node): boolean {
+  const literals = findAll(body, n => {
+    if (n.type !== "struct_expression") return false;
+    const typeName = n.childForFieldName("name")?.text ?? "";
+    return typeName === "Instruction" || typeName.endsWith("::Instruction");
+  });
+  if (literals.length === 0) return false;
+  return literals.every(literal => {
+    const programId = findAll(literal, n => n.type === "field_initializer").find(
+      f => (f.childForFieldName("field") ?? f.namedChild(0))?.text === "program_id",
+    );
+    const value = programId?.childForFieldName("value") ?? programId?.namedChild(1);
+    return !!value && invokeUsesHardcodedProgramId(value);
+  });
+}
+
+function enclosingModule(node: Node): Node | null {
+  let cursor: Node | null = node.parent;
+  while (cursor) {
+    if (cursor.type === "mod_item") return cursor;
+    cursor = cursor.parent;
+  }
+  return null;
+}
+
+function fileImportsName(tree: Tree, name: string): boolean {
+  return (
+    findAll(tree.rootNode, n => {
+      if (n.type !== "use_declaration") return false;
+      return findAll(n, id => id.type === "identifier" && id.text === name).length > 0;
+    }).length > 0
+  );
+}
+
+function isLocalInstructionBuilder(tree: Tree, call: Node, name: string): boolean {
+  // An import of the same name may shadow the local definition, and the imported
+  // body is not in the submitted text.
+  if (fileImportsName(tree, name)) return false;
   const matches = findAll(tree.rootNode, n => {
     if (n.type !== "function_item") return false;
     return n.childForFieldName("name")?.text === name;
@@ -166,10 +203,11 @@ function isLocalInstructionBuilder(tree: Tree, name: string): boolean {
   // A duplicated name (concatenated modules) makes the call unattributable, so don't trust it.
   if (matches.length !== 1) return false;
   const fn = matches[0];
+  if (enclosingModule(fn) !== enclosingModule(call)) return false;
   const returnType = fn.childForFieldName("return_type");
   if (!returnType?.text.includes("Instruction")) return false;
   const body = fn.childForFieldName("body");
-  return !!body && invokeUsesHardcodedProgramId(body);
+  return !!body && buildsInstructionWithHardcodedId(body);
 }
 
 function builtByLocalHardcodedBuilder(tree: Tree, candidates: Node[]): boolean {
@@ -182,7 +220,7 @@ function builtByLocalHardcodedBuilder(tree: Tree, candidates: Node[]): boolean {
       // function by name alone.
       const fn = n.childForFieldName("function");
       if (fn?.type !== "identifier") return;
-      if (isLocalInstructionBuilder(tree, fn.text)) hardcoded = true;
+      if (isLocalInstructionBuilder(tree, n, fn.text)) hardcoded = true;
     });
     if (hardcoded) return true;
   }

--- a/lib/tools/programAutofixer/visitors/program-id-verification.ts
+++ b/lib/tools/programAutofixer/visitors/program-id-verification.ts
@@ -1,31 +1,11 @@
-import type { Node } from "web-tree-sitter";
 import type { Visitor } from "../types.js";
 import { formatLocation } from "../types.js";
-import { getCallName, walk } from "../walk.js";
 import {
   KEY_MARKERS,
   bodyContainsRejectingCheckFor,
-  getCallArgs,
+  fileContainsProgramVerifyFor,
   isProgramAccountName,
-  rootIdentifierOf,
 } from "./_helpers.js";
-
-const PROGRAM_VERIFY_NAME_RE = /^(verify|check|assert)_.*program/;
-const EXTRA_PROGRAM_VERIFY_NAMES = new Set(["check_id", "check_program_id", "assert_program_id", "verify_program"]);
-
-function fileContainsProgramVerifyFor(root: Node, account: string): boolean {
-  let found = false;
-  walk(root, n => {
-    if (found) return "skip";
-    if (n.type !== "call_expression") return;
-    const fn = n.childForFieldName("function");
-    const name = fn ? getCallName(fn) : null;
-    if (!name) return;
-    if (!PROGRAM_VERIFY_NAME_RE.test(name) && !EXTRA_PROGRAM_VERIFY_NAMES.has(name)) return;
-    if (getCallArgs(n).some(a => rootIdentifierOf(a) === account)) found = true;
-  });
-  return found;
-}
 
 export const programIdVerification: Visitor = {
   name: "program-id-verification",

--- a/tests/unit/programAutofixer/fixtures-pinocchio.ts
+++ b/tests/unit/programAutofixer/fixtures-pinocchio.ts
@@ -116,6 +116,40 @@ pub fn forward(system_program: &AccountView, token_program: &AccountView, ix: &I
 }
 `;
 
+export const SECURE_CPI_VERIFIED_IN_TRY_FROM = `use pinocchio::cpi::{invoke, Instruction};
+pub struct Forward<'a> { pub token_program: &'a AccountView }
+impl<'a> Forward<'a> {
+  pub fn try_from(accounts: &'a [AccountView]) -> Result<Self, ProgramError> {
+    let [token_program] = accounts else { return Err(ProgramError::NotEnoughAccountKeys) };
+    verify_token_program(token_program)?;
+    Ok(Self { token_program })
+  }
+}
+pub fn forward(token_program: &AccountView, ix: &Instruction) -> Result<(), ProgramError> {
+  invoke(ix, &[token_program.clone()])
+}
+`;
+
+export const SECURE_CPI_LOCAL_BUILDER = `use pinocchio::cpi::{invoke, Instruction};
+fn transfer_ix(from: &AccountView, to: &AccountView) -> Instruction {
+  Instruction { program_id: &pinocchio_token::ID, accounts: &[], data: &[] }
+}
+pub fn forward(from: &AccountView, to: &AccountView, program: &AccountView) -> Result<(), ProgramError> {
+  let ix = transfer_ix(from, to);
+  invoke(&ix, &[program.clone()])
+}
+`;
+
+export const VULNERABLE_CPI_LOCAL_BUILDER_CALLER_ID = `use pinocchio::cpi::{invoke, Instruction};
+fn transfer_ix(program_id: &Pubkey, from: &AccountView, to: &AccountView) -> Instruction {
+  Instruction { program_id, accounts: &[], data: &[] }
+}
+pub fn forward(program_id: &Pubkey, from: &AccountView, to: &AccountView, program: &AccountView) -> Result<(), ProgramError> {
+  let ix = transfer_ix(program_id, from, to);
+  invoke(&ix, &[program.clone()])
+}
+`;
+
 export const VULNERABLE_PDA = `use pinocchio::pubkey::find_program_address;
 pub fn handle(account: &AccountView, seed: &[u8]) -> Result<(), ProgramError> {
   let (pda, _bump) = find_program_address(&[seed], &crate::ID);

--- a/tests/unit/programAutofixer/fixtures-pinocchio.ts
+++ b/tests/unit/programAutofixer/fixtures-pinocchio.ts
@@ -140,6 +140,35 @@ pub fn forward(from: &AccountView, to: &AccountView, program: &AccountView) -> R
 }
 `;
 
+export const VULNERABLE_CPI_DUPLICATE_BUILDER_NAME = `use pinocchio::cpi::{invoke, Instruction};
+mod safe {
+  pub fn transfer_ix(from: &AccountView, to: &AccountView) -> Instruction {
+    Instruction { program_id: &pinocchio_token::ID, accounts: &[], data: &[] }
+  }
+}
+mod unsafe_path {
+  pub fn transfer_ix(program_id: &Pubkey, from: &AccountView, to: &AccountView) -> Instruction {
+    Instruction { program_id, accounts: &[], data: &[] }
+  }
+}
+pub fn forward(program_id: &Pubkey, from: &AccountView, to: &AccountView, program: &AccountView) -> Result<(), ProgramError> {
+  let ix = transfer_ix(program_id, from, to);
+  invoke(&ix, &[program.clone()])
+}
+`;
+
+export const VULNERABLE_CPI_QUALIFIED_BUILDER = `use pinocchio::cpi::{invoke, Instruction};
+mod safe {
+  pub fn transfer_ix(from: &AccountView, to: &AccountView) -> Instruction {
+    Instruction { program_id: &pinocchio_token::ID, accounts: &[], data: &[] }
+  }
+}
+pub fn forward(from: &AccountView, to: &AccountView, program: &AccountView) -> Result<(), ProgramError> {
+  let ix = attacker::transfer_ix(from, to);
+  invoke(&ix, &[program.clone()])
+}
+`;
+
 export const VULNERABLE_CPI_LOCAL_BUILDER_CALLER_ID = `use pinocchio::cpi::{invoke, Instruction};
 fn transfer_ix(program_id: &Pubkey, from: &AccountView, to: &AccountView) -> Instruction {
   Instruction { program_id, accounts: &[], data: &[] }

--- a/tests/unit/programAutofixer/fixtures-pinocchio.ts
+++ b/tests/unit/programAutofixer/fixtures-pinocchio.ts
@@ -157,6 +157,32 @@ pub fn forward(program_id: &Pubkey, from: &AccountView, to: &AccountView, progra
 }
 `;
 
+export const VULNERABLE_CPI_IMPORTED_BUILDER = `use pinocchio::cpi::{invoke, Instruction};
+mod safe {
+  pub fn transfer_ix(from: &AccountView, to: &AccountView) -> Instruction {
+    Instruction { program_id: &pinocchio_token::ID, accounts: &[], data: &[] }
+  }
+}
+mod caller {
+  use crate::other_file::transfer_ix;
+  pub fn forward(program_id: &Pubkey, from: &AccountView, program: &AccountView) -> Result<(), ProgramError> {
+    let ix = transfer_ix(program_id, from);
+    invoke(&ix, &[program.clone()])
+  }
+}
+`;
+
+export const VULNERABLE_CPI_BUILDER_DECOY_ID = `use pinocchio::cpi::{invoke, Instruction};
+fn transfer_ix(program_id: &Pubkey, from: &AccountView) -> Instruction {
+  let _expected_program = pinocchio_token::ID;
+  Instruction { program_id, accounts: &[], data: &[] }
+}
+pub fn forward(program_id: &Pubkey, from: &AccountView, program: &AccountView) -> Result<(), ProgramError> {
+  let ix = transfer_ix(program_id, from);
+  invoke(&ix, &[program.clone()])
+}
+`;
+
 export const VULNERABLE_CPI_QUALIFIED_BUILDER = `use pinocchio::cpi::{invoke, Instruction};
 mod safe {
   pub fn transfer_ix(from: &AccountView, to: &AccountView) -> Instruction {

--- a/tests/unit/programAutofixer/visitors-pinocchio.test.ts
+++ b/tests/unit/programAutofixer/visitors-pinocchio.test.ts
@@ -16,6 +16,8 @@ import {
   SECURE_CPI_VERIFIED_IN_TRY_FROM,
   SECURE_CPI_LOCAL_BUILDER,
   VULNERABLE_CPI_LOCAL_BUILDER_CALLER_ID,
+  VULNERABLE_CPI_DUPLICATE_BUILDER_NAME,
+  VULNERABLE_CPI_QUALIFIED_BUILDER,
   VULNERABLE_PDA,
   SECURE_PDA,
   VULNERABLE_SYSVAR,
@@ -304,6 +306,18 @@ describe("program_autofixer regression cases (no regex fallbacks)", () => {
     const out = await runProgramAutofixer({ code: VULNERABLE_CPI_LOCAL_BUILDER_CALLER_ID, framework: "pinocchio" });
     const hit = out.issues.find(i => i.rule === "arbitrary-cpi");
     expect(hit, "arbitrary-cpi trusted a builder that forwards a caller-supplied program id").toBeDefined();
+  }, 20_000);
+
+  it("flags arbitrary-cpi when two builders share a name and only one hardcodes the id", async () => {
+    const out = await runProgramAutofixer({ code: VULNERABLE_CPI_DUPLICATE_BUILDER_NAME, framework: "pinocchio" });
+    const hit = out.issues.find(i => i.rule === "arbitrary-cpi");
+    expect(hit, "arbitrary-cpi resolved an ambiguous builder name to the trusted function").toBeDefined();
+  }, 20_000);
+
+  it("flags arbitrary-cpi when the builder is called through a qualified path", async () => {
+    const out = await runProgramAutofixer({ code: VULNERABLE_CPI_QUALIFIED_BUILDER, framework: "pinocchio" });
+    const hit = out.issues.find(i => i.rule === "arbitrary-cpi");
+    expect(hit, "arbitrary-cpi matched a qualified call to a same-named local builder").toBeDefined();
   }, 20_000);
 
   it("does not flag unchecked-arithmetic on account-layout `len()` math", async () => {

--- a/tests/unit/programAutofixer/visitors-pinocchio.test.ts
+++ b/tests/unit/programAutofixer/visitors-pinocchio.test.ts
@@ -13,6 +13,9 @@ import {
   SECURE_CPI,
   VULNERABLE_CPI_MISMATCHED_VERIFY,
   VULNERABLE_CPI_PARTIAL_VERIFY,
+  SECURE_CPI_VERIFIED_IN_TRY_FROM,
+  SECURE_CPI_LOCAL_BUILDER,
+  VULNERABLE_CPI_LOCAL_BUILDER_CALLER_ID,
   VULNERABLE_PDA,
   SECURE_PDA,
   VULNERABLE_SYSVAR,
@@ -283,6 +286,24 @@ describe("program_autofixer regression cases (no regex fallbacks)", () => {
     const out = await runProgramAutofixer({ code: VULNERABLE_CPI_PARTIAL_VERIFY, framework: "pinocchio" });
     const hit = out.issues.find(i => i.rule === "arbitrary-cpi");
     expect(hit, "arbitrary-cpi missed invoke with a partially verified program account list").toBeDefined();
+  }, 20_000);
+
+  it("does not flag arbitrary-cpi when the program is verified in the accounts struct try_from", async () => {
+    const out = await runProgramAutofixer({ code: SECURE_CPI_VERIFIED_IN_TRY_FROM, framework: "pinocchio" });
+    const hit = out.issues.find(i => i.rule === "arbitrary-cpi");
+    expect(hit, "arbitrary-cpi ignored verification outside the invoking fn").toBeUndefined();
+  }, 20_000);
+
+  it("does not flag arbitrary-cpi when a local builder hardcodes the program id", async () => {
+    const out = await runProgramAutofixer({ code: SECURE_CPI_LOCAL_BUILDER, framework: "pinocchio" });
+    const hit = out.issues.find(i => i.rule === "arbitrary-cpi");
+    expect(hit, "arbitrary-cpi ignored a local builder hardcoding the program id").toBeUndefined();
+  }, 20_000);
+
+  it("flags arbitrary-cpi when the local builder takes the program id from the caller", async () => {
+    const out = await runProgramAutofixer({ code: VULNERABLE_CPI_LOCAL_BUILDER_CALLER_ID, framework: "pinocchio" });
+    const hit = out.issues.find(i => i.rule === "arbitrary-cpi");
+    expect(hit, "arbitrary-cpi trusted a builder that forwards a caller-supplied program id").toBeDefined();
   }, 20_000);
 
   it("does not flag unchecked-arithmetic on account-layout `len()` math", async () => {

--- a/tests/unit/programAutofixer/visitors-pinocchio.test.ts
+++ b/tests/unit/programAutofixer/visitors-pinocchio.test.ts
@@ -18,6 +18,8 @@ import {
   VULNERABLE_CPI_LOCAL_BUILDER_CALLER_ID,
   VULNERABLE_CPI_DUPLICATE_BUILDER_NAME,
   VULNERABLE_CPI_QUALIFIED_BUILDER,
+  VULNERABLE_CPI_IMPORTED_BUILDER,
+  VULNERABLE_CPI_BUILDER_DECOY_ID,
   VULNERABLE_PDA,
   SECURE_PDA,
   VULNERABLE_SYSVAR,
@@ -318,6 +320,18 @@ describe("program_autofixer regression cases (no regex fallbacks)", () => {
     const out = await runProgramAutofixer({ code: VULNERABLE_CPI_QUALIFIED_BUILDER, framework: "pinocchio" });
     const hit = out.issues.find(i => i.rule === "arbitrary-cpi");
     expect(hit, "arbitrary-cpi matched a qualified call to a same-named local builder").toBeDefined();
+  }, 20_000);
+
+  it("flags arbitrary-cpi when a bare builder call resolves through an import", async () => {
+    const out = await runProgramAutofixer({ code: VULNERABLE_CPI_IMPORTED_BUILDER, framework: "pinocchio" });
+    const hit = out.issues.find(i => i.rule === "arbitrary-cpi");
+    expect(hit, "arbitrary-cpi attributed an imported call to an out-of-scope local builder").toBeDefined();
+  }, 20_000);
+
+  it("flags arbitrary-cpi when the builder's hardcoded id is unrelated to the instruction", async () => {
+    const out = await runProgramAutofixer({ code: VULNERABLE_CPI_BUILDER_DECOY_ID, framework: "pinocchio" });
+    const hit = out.issues.find(i => i.rule === "arbitrary-cpi");
+    expect(hit, "arbitrary-cpi trusted a builder whose ::ID never reaches the instruction").toBeDefined();
   }, 20_000);
 
   it("does not flag unchecked-arithmetic on account-layout `len()` math", async () => {


### PR DESCRIPTION
## Summary
- `arbitrary-cpi` only looked for program-id verification inside the enclosing function body, so verification in an accounts-struct `try_from` and project-local instruction builders were invisible. Verification lookup now runs at file scope and resolves local builders one level deep.
- File-scope verification requires *every* program-shaped account in the `invoke` to be verified, matching the existing all-must-be-verified semantics of `invokeUsesVerifiedProgram`; a partially verified account list still fires.
- A local builder only counts as trusted when it returns `Instruction` and hardcodes `::ID` in its body. A builder forwarding a caller-supplied program id still fires.
- Moved `fileContainsProgramVerifyFor` from `program-id-verification.ts` into `_helpers.ts` (now shared by both visitors) and added `tree` to `VisitorContext`.
- Reworded `falsePositiveWhen` entries 0 and 1 in place, keeping indices stable so historical `matched_hint` telemetry stays comparable.

## Motivation
Dismissal telemetry, 30d: `arbitrary-cpi` fired 191 times, the most of any rule, and hit the ~52% dismissal ceiling, meaning it was dismissed on essentially every fire. Hints 0 (63 dismissals) and 1 (62) accounted for 125 of them, and both describe verification outside the analyzed function. Because the rule is `critical` it also gated `require_another_tool_call_after_fixing`, burning an extra round-trip per bogus hit.

## Tradeoff
Both widenings trade false positives for potential false negatives: a helper named `verify_*_program` that doesn't actually verify would now silence a critical finding. That matches the convention the other six `try_from`-aware visitors already accept, and the rule protects nobody today given the dismissal rate.

## Test Plan
- 3 new cases in `tests/unit/programAutofixer/visitors-pinocchio.test.ts`: verification in `try_from` (suppressed), local builder hardcoding the id (suppressed), local builder forwarding a caller-supplied id (still fires).
- Verified the two suppression tests fail on `main`'s visitor code and pass with the fix; the negative case passes both ways.
- `pnpm exec vitest run tests/unit/` 219 passed, `pnpm typecheck:ts` clean, `pnpm lint` clean, `pnpm format:check` clean.