### PR TITLE
fix(autofixer): recognize more program binding names in arbitrary-cpi

### DIFF
--- a/lib/tools/programAutofixer/visitors/arbitrary-cpi.ts
+++ b/lib/tools/programAutofixer/visitors/arbitrary-cpi.ts
@@ -115,10 +115,12 @@ function collectRootIdentifiers(node: Node): Set<string> {
   return roots;
 }
 
+const PROGRAM_SHAPED_RE = /(^|_)prog(ram)?(_|$)/;
+
 function programShapedRoots(roots: ReadonlySet<string>): Set<string> {
   const out = new Set<string>();
   for (const root of roots) {
-    if (root === "program" || root.endsWith("_program") || isProgramAccountName(root)) out.add(root);
+    if (PROGRAM_SHAPED_RE.test(root) || isProgramAccountName(root)) out.add(root);
   }
   return out;
 }
@@ -232,10 +234,11 @@ export const arbitraryCpi: Visitor = {
   severity: "critical",
   appliesTo: ["pinocchio"],
   falsePositiveWhen: [
-    "program id verified in a helper in another file, outside the submitted text",
-    "instruction built by a project-local builder in another file, called via a qualified path or method, sharing its name with another function, or not returning Instruction",
+    "program id verified in a helper outside this fn, in this file or another",
+    "instruction built by a project-local builder hardcoding the id internally, in this file or another",
     "program binding name not program-shaped so verification unattributed",
     "instruction flows through match/closure/struct-field bindings untraceable to ::ID",
+    "program verified in this file in some other shape the rule does not recognize",
   ],
   enter: {
     call_expression(node, ctx) {

--- a/tests/unit/programAutofixer/fixtures-pinocchio.ts
+++ b/tests/unit/programAutofixer/fixtures-pinocchio.ts
@@ -130,6 +130,26 @@ pub fn forward(token_program: &AccountView, ix: &Instruction) -> Result<(), Prog
 }
 `;
 
+export const SECURE_CPI_PROGRAM_INFO_NAME = `use pinocchio::cpi::{invoke, Instruction};
+pub struct Forward<'a> { pub token_program_info: &'a AccountView }
+impl<'a> Forward<'a> {
+  pub fn try_from(accounts: &'a [AccountView]) -> Result<Self, ProgramError> {
+    let [token_program_info] = accounts else { return Err(ProgramError::NotEnoughAccountKeys) };
+    verify_token_program(token_program_info)?;
+    Ok(Self { token_program_info })
+  }
+}
+pub fn forward(token_program_info: &AccountView, ix: &Instruction) -> Result<(), ProgramError> {
+  invoke(ix, &[token_program_info.clone()])
+}
+`;
+
+export const VULNERABLE_CPI_PROGRAM_INFO_UNVERIFIED = `use pinocchio::cpi::{invoke, Instruction};
+pub fn forward(token_program_info: &AccountView, ix: &Instruction) -> Result<(), ProgramError> {
+  invoke(ix, &[token_program_info.clone()])
+}
+`;
+
 export const SECURE_CPI_LOCAL_BUILDER = `use pinocchio::cpi::{invoke, Instruction};
 fn transfer_ix(from: &AccountView, to: &AccountView) -> Instruction {
   Instruction { program_id: &pinocchio_token::ID, accounts: &[], data: &[] }

--- a/tests/unit/programAutofixer/visitors-pinocchio.test.ts
+++ b/tests/unit/programAutofixer/visitors-pinocchio.test.ts
@@ -14,6 +14,8 @@ import {
   VULNERABLE_CPI_MISMATCHED_VERIFY,
   VULNERABLE_CPI_PARTIAL_VERIFY,
   SECURE_CPI_VERIFIED_IN_TRY_FROM,
+  SECURE_CPI_PROGRAM_INFO_NAME,
+  VULNERABLE_CPI_PROGRAM_INFO_UNVERIFIED,
   SECURE_CPI_LOCAL_BUILDER,
   VULNERABLE_CPI_LOCAL_BUILDER_CALLER_ID,
   VULNERABLE_CPI_DUPLICATE_BUILDER_NAME,
@@ -296,6 +298,18 @@ describe("program_autofixer regression cases (no regex fallbacks)", () => {
     const out = await runProgramAutofixer({ code: SECURE_CPI_VERIFIED_IN_TRY_FROM, framework: "pinocchio" });
     const hit = out.issues.find(i => i.rule === "arbitrary-cpi");
     expect(hit, "arbitrary-cpi ignored verification outside the invoking fn").toBeUndefined();
+  }, 20_000);
+
+  it("does not flag arbitrary-cpi when the verified program binding is named *_program_info", async () => {
+    const out = await runProgramAutofixer({ code: SECURE_CPI_PROGRAM_INFO_NAME, framework: "pinocchio" });
+    const hit = out.issues.find(i => i.rule === "arbitrary-cpi");
+    expect(hit, "arbitrary-cpi ignored verification of a non-*_program binding name").toBeUndefined();
+  }, 20_000);
+
+  it("flags arbitrary-cpi when a *_program_info binding is never verified", async () => {
+    const out = await runProgramAutofixer({ code: VULNERABLE_CPI_PROGRAM_INFO_UNVERIFIED, framework: "pinocchio" });
+    const hit = out.issues.find(i => i.rule === "arbitrary-cpi");
+    expect(hit, "arbitrary-cpi treated a program-shaped name as verified without a verify call").toBeDefined();
   }, 20_000);
 
   it("does not flag arbitrary-cpi when a local builder hardcodes the program id", async () => {


### PR DESCRIPTION
## Summary
- Widen the program-binding name test in `arbitrary-cpi` so spellings like `token_program_info` are recognized, letting in-file verification suppress the warning. `arbitrary-cpi` is by a wide margin the most-dismissed rule in the dismissal telemetry, and unattributable binding names are its largest diagnosable bucket.
- Restore the in-file wording to `false_positive_hints` 0 and 1. 9bbf0be narrowed both to "in another file", but the in-file case is only partly handled, so dismissals citing in-file verification had no hint to match.
- Add a hint for verification shapes the rule does not recognize, so the `other` bucket stops being opaque and the next telemetry pass can tell these cases apart.
- Bidirectional fixtures: a verified `*_program_info` binding must stop firing, an unverified one must still fire.

## Test Plan
- `pnpm test` (227 pass), `pnpm lint`, `pnpm typecheck` clean.
- Verified the new secure fixture fails against the old narrow name test, so the test can actually detect a regression.

## Notes
Widening the name test only moves a case from "fire unconditionally" to "fire unless verified": an unrecognized name short-circuits to a report today. The residual false-negative risk is a binding such as `program_data` that happens to be passed to some `check_*_program(...)` call and would now count as verified.

Whether this worked is not knowable from tests. It is gradeable only from dismissal telemetry weeks out.